### PR TITLE
Fix fuzz CI job; recognize rib(s) as a unit

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,9 @@ jobs:
         with:
           toolchain: nightly
           components: rust-src
+          # cargo-fuzz defaults to the musl target on Linux, where ASan is
+          # incompatible with the static libc. Build/run against gnu instead.
+          target: x86_64-unknown-linux-gnu
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-fuzz
@@ -86,7 +89,7 @@ jobs:
         working-directory: ingredient-parser
         run: |
           for target in from_str parse_amount rich_text; do
-            cargo +nightly fuzz run "$target" -- -max_total_time=30 -rss_limit_mb=4096
+            cargo +nightly fuzz run "$target" --target x86_64-unknown-linux-gnu -- -max_total_time=30 -rss_limit_mb=4096
           done
   bench:
     name: benchmarks (smoke)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,7 +78,9 @@ jobs:
         with:
           toolchain: nightly
           components: rust-src
-      - uses: taiki-e/install-action@cargo-fuzz
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
       - name: Smoke-fuzz each target (30s each)
         # Short run to catch crashes/panics on PRs; deep runs are manual/scheduled.
         working-directory: ingredient-parser

--- a/ingredient-parser/src/lib.rs
+++ b/ingredient-parser/src/lib.rs
@@ -276,6 +276,7 @@ impl IngredientParser {
         let units: HashSet<String> = [
             "recipe", "packet", "sticks", "stick", "cloves", "clove", "bunch", "head", "pinch",
             "package", "slice", "slices", "standard", "can", "leaf", "leaves", "strand", "tin",
+            "rib", "ribs",
         ]
         .iter()
         .map(|&s| s.into())

--- a/ingredient-parser/tests/corpus/corpus.jsonl
+++ b/ingredient-parser/tests/corpus/corpus.jsonl
@@ -26,6 +26,7 @@
 {"input": "2 sticks unsalted butter", "name": "unsalted butter", "amounts": [{"unit": "stick", "value": 2}]}
 {"input": "1 pinch saffron", "name": "saffron", "amounts": [{"unit": "pinch", "value": 1}]}
 {"input": "1 bunch cilantro", "name": "cilantro", "amounts": [{"unit": "bunch", "value": 1}]}
+{"input": "2 ribs celery, chopped", "name": "celery", "amounts": [{"unit": "rib", "value": 2}], "modifier": "chopped"}
 {"input": "a pinch of salt", "name": "salt", "amounts": [{"unit": "pinch", "value": 1}]}
 //
 // --- fractions and decimals ---
@@ -79,4 +80,3 @@
 {"input": "Juice of 1 lemon", "name": "lemon", "amounts": [{"unit": "whole", "value": 1}], "modifier": "juice of", "xfail": "'X of N item' construction falls back to name-only"}
 {"input": "Zest of 1 lemon", "name": "lemon", "amounts": [{"unit": "whole", "value": 1}], "modifier": "zest of", "xfail": "'X of N item' construction falls back to name-only"}
 {"input": "1 cup packed brown sugar", "name": "brown sugar", "amounts": [{"unit": "cup", "value": 1}], "modifier": "packed", "xfail": "leading prep word 'packed' not extracted to modifier"}
-{"input": "2 ribs celery, chopped", "name": "celery", "amounts": [{"unit": "rib", "value": 2}], "modifier": "chopped", "xfail": "'rib(s)' not a recognized unit; absorbed into name"}


### PR DESCRIPTION
## Fixes
- **CI**: the `fuzz (smoke)` job failed on main (`no such command: fuzz`) because `taiki-e/install-action@cargo-fuzz` didn't install the tool. Switched to the canonical `@v2` + `with: tool: cargo-fuzz` form.

## Phase 2 (parser quality)
- Recognize `rib`/`ribs` as a default unit, so `2 ribs celery, chopped` parses as 2 ribs of celery. Promotes the accuracy-corpus row from `xfail` to committed — **exact match 92% → 94%**.

Verified locally: 663 tests, clippy `-D warnings`, accuracy harness all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)