### PR TITLE
Fix parser losing the ingredient name into the modifier

### DIFF
--- a/ingredient-parser/src/parser/pipeline.rs
+++ b/ingredient-parser/src/parser/pipeline.rs
@@ -50,6 +50,20 @@ impl IngredientParser {
         }
 
         self.parse_core_ingredient(input)
+            // Reject a "successful" parse that lost the ingredient name into the
+            // modifier (seen on real recipes: a decimal comma in "1,000 grams
+            // ... nectarines", a leading prep word, etc.) — the graceful
+            // fallback is better than a name-less ingredient with garbled text.
+            // A bare quantity like "1/2-1 cup" legitimately has no name, so only
+            // fall back when the empty name coincides with leftover modifier text.
+            .filter(|ingredient| {
+                let name_empty = ingredient.name.trim().is_empty();
+                let has_modifier = ingredient
+                    .modifier
+                    .as_deref()
+                    .is_some_and(|m| !m.trim().is_empty());
+                !(name_empty && has_modifier)
+            })
             .unwrap_or_else(|| fallback_ingredient(input))
     }
 

--- a/ingredient-parser/tests/accuracy.rs
+++ b/ingredient-parser/tests/accuracy.rs
@@ -147,3 +147,30 @@ fn accuracy_corpus() {
         regressions.len()
     );
 }
+
+/// Regression guard for the "name lost into the modifier" failures found on real
+/// recipes (decimal commas like "1,000 grams", leading prep words, unicode inch
+/// marks): a labeled ingredient line must never parse to an empty name. (A bare
+/// quantity like "1/2-1 cup" may legitimately have no name, so this covers only
+/// the corpus inputs plus known-tricky real lines.)
+#[test]
+fn never_empty_name() {
+    let mut inputs: Vec<String> = load().into_iter().map(|r| r.input).collect();
+    inputs.extend(
+        [
+            "1,000 grams (about 6 cups) quartered and pitted nectarines",
+            "2/3 cup (85 grams) finely chopped, raw pistachios",
+            "1/2 \u{201d} (1 cm) ginger, minced",
+            "0.44 ounces salt (about 2 1/2 teaspoons) salt",
+        ]
+        .iter()
+        .map(ToString::to_string),
+    );
+    for input in inputs {
+        let ing = from_str(&input);
+        assert!(
+            !ing.name.trim().is_empty(),
+            "parsed an empty name for input {input:?}"
+        );
+    }
+}

--- a/ingredient-parser/tests/corpus/corpus.jsonl
+++ b/ingredient-parser/tests/corpus/corpus.jsonl
@@ -76,7 +76,14 @@
 {"input": "Chocolate Chip Cookies", "name": "Chocolate Chip Cookies"}
 {"input": "freshly ground black pepper", "name": "black pepper", "modifier": "freshly ground"}
 //
+// --- real-world lines (from recipe-scraper test_data) ---
+{"input": "2 cups/250 grams all-purpose flour", "name": "all-purpose flour", "amounts": [{"unit": "cup", "value": 2}, {"unit": "g", "value": 250}]}
+{"input": "1 1/2 cups (190 grams) all-purpose flour", "name": "all-purpose flour", "amounts": [{"unit": "cup", "value": 1.5}, {"unit": "g", "value": 190}]}
+{"input": "1 large egg, room temperature", "name": "large egg", "amounts": [{"unit": "whole", "value": 1}], "modifier": "room temperature"}
+//
 // --- known gaps (xfail = desired parse the parser does not yet produce) ---
 {"input": "Juice of 1 lemon", "name": "lemon", "amounts": [{"unit": "whole", "value": 1}], "modifier": "juice of", "xfail": "'X of N item' construction falls back to name-only"}
 {"input": "Zest of 1 lemon", "name": "lemon", "amounts": [{"unit": "whole", "value": 1}], "modifier": "zest of", "xfail": "'X of N item' construction falls back to name-only"}
 {"input": "1 cup packed brown sugar", "name": "brown sugar", "amounts": [{"unit": "cup", "value": 1}], "modifier": "packed", "xfail": "leading prep word 'packed' not extracted to modifier"}
+{"input": "1,000 grams (about 6 cups) quartered and pitted nectarines", "name": "quartered and pitted nectarines", "amounts": [{"unit": "g", "value": 1000}], "xfail": "decimal-comma thousands separator '1,000' not parsed; now falls back to full-input name (no longer empty)"}
+{"input": "2/3 cup (85 grams) finely chopped, raw pistachios", "name": "raw pistachios", "amounts": [{"unit": "cup", "value": 0.667}, {"unit": "g", "value": 85}], "modifier": "finely chopped", "xfail": "leading prep phrase before name; now falls back to full-input name (no longer empty)"}

--- a/ingredient-parser/tests/trace.rs
+++ b/ingredient-parser/tests/trace.rs
@@ -558,14 +558,15 @@ fn test_trace_collector_default() {
 // ============================================================================
 
 /// Test that parse_with_trace handles various edge cases gracefully.
-/// Note: The parser is designed to be very permissive - most inputs parse
-/// successfully (possibly with empty name). These tests document this behavior.
+/// Note: The parser is permissive. A bare quantity may have an empty name
+/// ("12345"), but when leftover text would otherwise be orphaned in the
+/// modifier, the parse falls back to the input as the name ("@#$%").
 #[rstest]
 #[case::empty("", "")]
 #[case::whitespace("   ", "")]
 #[case::newline_only("\n", "")]
-#[case::numbers_only("12345", "")] // Numbers parsed as measurement, name is empty
-#[case::special_chars("@#$%", "")]
+#[case::numbers_only("12345", "")] // Bare quantity: amount parsed, name legitimately empty
+#[case::special_chars("@#$%", "@#$%")] // Junk would orphan in the modifier -> fall back to input
 fn test_parse_with_trace_edge_cases(
     parser: IngredientParser,
     #[case] input: &str,


### PR DESCRIPTION
## What & why
Auditing the parser against **130 real ingredient lines** from `recipe-scraper/test_data` surfaced a severe bug class: 3 lines produced an **empty name**, orphaning the real ingredient name in the modifier:
- `1,000 grams (about 6 cups) ... nectarines` — decimal-comma thousands separator
- `2/3 cup (85 grams) finely chopped, raw pistachios` — leading prep phrase
- `1/2 ” (1 cm) ginger` — unicode inch mark

An empty name is the worst output for a parser whose core job is naming the ingredient.

## Fix
Guard the main parse path: when a parse yields an empty name **and** leftover modifier text, fall back to the graceful name-only result. A bare quantity like `1/2-1 cup` legitimately has no name, so the guard fires only when the empty name coincides with orphaned modifier text.

- `never_empty_name` regression test (corpus inputs + known-tricky real lines)
- corpus grown with 5 real lines (3 committed, 2 documenting the remaining ideal as `xfail`)
- trace edge-case expectations updated to the new behavior

Verified: 703 workspace tests, clippy `-D warnings`, accuracy harness — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)