### PR TITLE
Parse thousands separators ("1,000" -> 1000)

### DIFF
--- a/ingredient-parser/src/parser/helpers.rs
+++ b/ingredient-parser/src/parser/helpers.rs
@@ -4,10 +4,11 @@
 
 use nom::{
     branch::alt,
-    bytes::complete::{tag, take_while1},
-    character::complete::alpha1,
+    bytes::complete::{tag, take_while1, take_while_m_n},
+    character::complete::{alpha1, char},
+    combinator::{map_res, opt, recognize},
     error::context,
-    multi::many0,
+    multi::{many0, many1},
     number::complete::double,
     IResult, Parser,
 };
@@ -76,8 +77,27 @@ pub(crate) fn parse_amount_string(input: &str) -> Result<Measure, String> {
 
 /// Parse a number using fraction or decimal parsing
 fn parse_number(input: &str) -> Res<&str, f64> {
-    // Try fraction first (handles "1/2", "1 ½", etc.), then fall back to decimal
-    alt((fraction_number, double)).parse(input)
+    // Fraction first ("1/2", "1 ½"), then thousands-separated integers ("1,000"),
+    // then a plain decimal. thousands_number must come before `double`, which
+    // would otherwise stop at the comma and parse "1,000" as just 1.
+    alt((fraction_number, thousands_number, double)).parse(input)
+}
+
+/// Parse a number written with thousands separators, e.g. "1,000" or "1,000,000"
+/// (optionally with a decimal part). The comma must be followed by exactly three
+/// digits, so this never matches list commas like "flour, sifted" or a European
+/// decimal comma like "1,5".
+pub(crate) fn thousands_number(input: &str) -> Res<&str, f64> {
+    let is_digit = |c: char| c.is_ascii_digit();
+    map_res(
+        recognize((
+            take_while_m_n(1, 3, is_digit),
+            many1((char(','), take_while_m_n(3, 3, is_digit))),
+            opt((char('.'), take_while1(is_digit))),
+        )),
+        |s: &str| s.replace(',', "").parse::<f64>(),
+    )
+    .parse(input)
 }
 
 /// Parse text characters for ingredient names.

--- a/ingredient-parser/src/parser/measurement/number.rs
+++ b/ingredient-parser/src/parser/measurement/number.rs
@@ -6,7 +6,7 @@ use nom::{
 };
 
 use crate::fraction::fraction_number;
-use crate::parser::{text_number, Res};
+use crate::parser::{text_number, thousands_number, Res};
 use crate::traced_parser;
 
 use super::MeasurementParser;
@@ -51,6 +51,7 @@ impl<'a> MeasurementParser<'a> {
                     "number",
                     alt((
                         fraction_number,           // Parse fractions like "½" or "1/2"
+                        thousands_number,          // Parse "1,000" before double stops at the comma
                         double_no_trailing_period, // Parse decimals without eating trailing periods
                     )),
                 )
@@ -60,9 +61,10 @@ impl<'a> MeasurementParser<'a> {
                 context(
                     "number",
                     alt((
-                        fraction_number, // Parse fractions like "½" or "1/2"
-                        text_number,     // Parse text numbers like "one" or "a"
-                        double,          // Parse decimal numbers like "2.5"
+                        fraction_number,  // Parse fractions like "½" or "1/2"
+                        text_number,      // Parse text numbers like "one" or "a"
+                        thousands_number, // Parse "1,000" before double stops at the comma
+                        double,           // Parse decimal numbers like "2.5"
                     )),
                 )
                 .parse(input)

--- a/ingredient-parser/src/parser/mod.rs
+++ b/ingredient-parser/src/parser/mod.rs
@@ -7,5 +7,7 @@ pub(crate) mod measurement;
 pub(crate) mod pipeline;
 
 pub(crate) use helpers::parse_amount_string;
-pub(crate) use helpers::{parse_ingredient_text, parse_unit_text, text_number, Res};
+pub(crate) use helpers::{
+    parse_ingredient_text, parse_unit_text, text_number, thousands_number, Res,
+};
 pub(crate) use measurement::MeasurementParser;

--- a/ingredient-parser/tests/corpus/corpus.jsonl
+++ b/ingredient-parser/tests/corpus/corpus.jsonl
@@ -192,9 +192,12 @@
 {"input": "All-purpose flour — 630 g", "name": "All-purpose flour", "amounts": [{"unit": "g", "value": 630.0}]}
 {"input": "Warm water (100°F/38°C) — 472 g", "name": "Warm water (100°F/38°C)", "amounts": [{"unit": "g", "value": 472.0}]}
 //
+// --- thousands separators ("1,000" -> 1000; comma must be followed by 3 digits) ---
+{"input": "1,000 grams flour", "name": "flour", "amounts": [{"unit": "g", "value": 1000}]}
+{"input": "1,000 grams (about 6 cups) quartered and pitted nectarines", "name": "quartered and pitted nectarines", "amounts": [{"unit": "g", "value": 1000}, {"unit": "cup", "value": 6}]}
+//
 // --- known gaps (xfail = desired parse the parser does not yet produce) ---
 {"input": "Juice of 1 lemon", "name": "lemon", "amounts": [{"unit": "whole", "value": 1}], "modifier": "juice of", "xfail": "'X of N item' construction falls back to name-only"}
 {"input": "Zest of 1 lemon", "name": "lemon", "amounts": [{"unit": "whole", "value": 1}], "modifier": "zest of", "xfail": "'X of N item' construction falls back to name-only"}
 {"input": "1 cup packed brown sugar", "name": "brown sugar", "amounts": [{"unit": "cup", "value": 1}], "modifier": "packed", "xfail": "leading prep word 'packed' not extracted to modifier"}
-{"input": "1,000 grams (about 6 cups) quartered and pitted nectarines", "name": "quartered and pitted nectarines", "amounts": [{"unit": "g", "value": 1000}], "xfail": "decimal-comma thousands separator '1,000' not parsed; now falls back to full-input name (no longer empty)"}
 {"input": "2/3 cup (85 grams) finely chopped, raw pistachios", "name": "raw pistachios", "amounts": [{"unit": "cup", "value": 0.667}, {"unit": "g", "value": 85}], "modifier": "finely chopped", "xfail": "leading prep phrase before name; now falls back to full-input name (no longer empty)"}

--- a/ingredient-parser/tests/parsing.rs
+++ b/ingredient-parser/tests/parsing.rs
@@ -147,6 +147,8 @@ fn test_custom_adjectives(
 #[case::unicode_mixed("1½ cups", vec![Measure::new("cups", 1.5)])]
 #[case::decimal("1.5 cups", vec![Measure::new("cups", 1.5)])]
 #[case::decimal_small("0.25 oz", vec![Measure::new("oz", 0.25)])]
+#[case::thousands("1,000 g", vec![Measure::new("g", 1000.0)])]
+#[case::thousands_millions("1,000,000 g", vec![Measure::new("g", 1000000.0)])]
 fn test_amount_parsing_basic(
     parser: IngredientParser,
     #[case] input: &str,


### PR DESCRIPTION
Closes a corpus `xfail`: `"1,000 grams ..."` was read as `1` (the `double` parser stops at the comma), which had cascaded into the empty-name fallback.

Adds a shared `thousands_number` parser wired into the measurement number parser **before** `double`. The comma must be followed by **exactly three digits**, so:
- `1,000` / `1,000,000` → 1000 / 1000000 ✅
- `flour, sifted` (list comma) → untouched ✅
- `1,5` (European decimal — separate i18n concern) → untouched ✅

- promotes `"1,000 grams (about 6 cups) ... nectarines"` from xfail → committed (now `1000 g` + the 6-cup secondary)
- corpus accuracy **96.9% → 97.5%** (4 xfail gaps remain)
- `parse_amount` rstest cases added

Verified: 650 tests + accuracy + clippy `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)