### PR TITLE
Fix panic: adjective extraction sliced name at a non-char boundary

### DIFF
--- a/ingredient-parser/src/parser/pipeline.rs
+++ b/ingredient-parser/src/parser/pipeline.rs
@@ -232,10 +232,19 @@ impl IngredientParser {
                 continue;
             };
 
+            let end = pos + adjective.len();
+            // `pos`/`end` are byte offsets into the lowercased name. Lowercasing
+            // can change byte lengths for some Unicode (e.g. 'İ' -> "i̇"), so these
+            // offsets may not fall on char boundaries in the original `name`.
+            // Skip rather than panic when slicing `name` would split a char.
+            if !name.is_char_boundary(pos) || !name.is_char_boundary(end) {
+                continue;
+            }
+
             append_modifier(&mut ingredient.modifier, adjective);
 
             let before = name[..pos].trim();
-            let after = name[pos + adjective.len()..].trim();
+            let after = name[end..].trim();
             let mut new_name = String::with_capacity(name.len());
             if !before.is_empty() {
                 new_name.push_str(before);

--- a/ingredient-parser/tests/parsing.rs
+++ b/ingredient-parser/tests/parsing.rs
@@ -92,6 +92,18 @@ fn test_parsing_equivalence(parser: IngredientParser, #[case] left: &str, #[case
     );
 }
 
+/// Regression (found by cargo-fuzz): adjective extraction byte-sliced `name` at
+/// offsets taken from its lowercased form. For chars whose lowercase changes
+/// byte length (e.g. 'İ' U+0130 -> "i̇"), those offsets can land off a char
+/// boundary or past the end, panicking. These must parse without panicking.
+#[rstest]
+#[case("1 cup İdiced")]
+#[case("İsliced")]
+#[case("1 İminced thing")]
+fn test_adjective_extraction_multibyte_no_panic(parser: IngredientParser, #[case] input: &str) {
+    let _ = parser.from_str(input);
+}
+
 // ============================================================================
 // Custom Parser Configuration Tests
 // ============================================================================


### PR DESCRIPTION
**Found by the cargo-fuzz CI gate** (it flagged this on a recent run). `extract_adjectives_from_name` byte-sliced the original `name` using offsets from its *lowercased* form. For chars whose lowercase changes byte length (e.g. `'İ'` U+0130 → `"i̇"`), those offsets can land off a char boundary or past the end and panic:

```
from_str("1 cup İdiced")  =>  byte index 8 is out of bounds of `İdiced`
```

This is a **pre-existing latent bug** (unrelated to recent changes — fuzzing is randomized and happened to surface it now).

**Fix:** guard the slice with `is_char_boundary` and skip extraction when slicing would be unsafe. Adds a deterministic regression rstest (`test_adjective_extraction_multibyte_no_panic`).

Verified: 653 tests, clippy `-D warnings`, and 60s of local `from_str` fuzzing with no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)