### PR TITLE
Phase 3: harden recipe-scraper robustness

### DIFF
--- a/recipe-scraper-fetcher/src/lib.rs
+++ b/recipe-scraper-fetcher/src/lib.rs
@@ -43,7 +43,16 @@ impl Fetcher {
         let r = match self
             .client
             .get(url)
-            .header("user-agent", "recipe")
+            // A bare "recipe" UA gets blocked by many sites; use a descriptive,
+            // browser-prefixed bot UA that real recipe sites generally accept.
+            .header(
+                "user-agent",
+                concat!(
+                    "Mozilla/5.0 (compatible; ingredient-parser/",
+                    env!("CARGO_PKG_VERSION"),
+                    "; +https://github.com/nickysemenza/ingredient-parser)"
+                ),
+            )
             .send()
             .await
         {

--- a/recipe-scraper/src/ld_json.rs
+++ b/recipe-scraper/src/ld_json.rs
@@ -108,7 +108,13 @@ fn normalize_root_recipe(
                 .map(|i| i.text().collect::<Vec<_>>().join(""))
                 .collect::<Vec<_>>()
         }
-        ld_schema::InstructionWrapper::D(d) => d[0].clone().into_iter().map(|i| i.text).collect(),
+        ld_schema::InstructionWrapper::D(d) => d
+            .first()
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|i| i.text)
+            .collect(),
     };
 
     // Parse yield if present
@@ -123,11 +129,11 @@ fn normalize_root_recipe(
         instructions,
         name: ld_schema.name,
         url: url.to_string(),
-        image: ld_schema.image.map(|image| match image {
-            ld_schema::ImageOrList::Url(i) => i,
-            ld_schema::ImageOrList::List(l) => l[0].url.clone(),
-            ld_schema::ImageOrList::UrlList(i) => i[0].clone(),
-            ld_schema::ImageOrList::Image(i) => i.url,
+        image: ld_schema.image.and_then(|image| match image {
+            ld_schema::ImageOrList::Url(i) => Some(i),
+            ld_schema::ImageOrList::List(l) => l.first().map(|x| x.url.clone()),
+            ld_schema::ImageOrList::UrlList(i) => i.first().cloned(),
+            ld_schema::ImageOrList::Image(i) => Some(i.url),
         }),
         recipe_yield,
         servings,

--- a/recipe-scraper/src/lib.rs
+++ b/recipe-scraper/src/lib.rs
@@ -81,30 +81,32 @@ impl ScrapedRecipe {
 // https://github.com/megametres/recettes-api/blob/dev/src/html_parser/mod.rs
 
 pub fn scrape(body: &str, url: &str) -> Result<ScrapedRecipe, ScrapeError> {
-    info!("scraping {} from {} ({:.10})", body.len(), url, body);
+    info!("scraping {} bytes from {url}", body.len());
     if url.contains("chefsteps.com") {
         info!("scraping chefsteps");
         return parse_chefsteps(body);
     }
     let dom = Html::parse_document(body);
-    let res = match extract_ld(dom.clone()) {
+
+    // Prefer LD+JSON, but fall back to HTML scraping on *any* LD failure —
+    // missing, malformed/undeserializable, or present-but-no-recipe — rather
+    // than erroring out. Previously only the "no ld+json at all" case degraded.
+    let from_ld = match extract_ld(dom.clone()) {
         Ok(ld_schemas) => {
             let items = ld_schemas.len();
-            match ld_schemas
+            ld_schemas
                 .into_iter()
-                .map(|ld| ld_json::scrape_from_ld_json(ld.as_str(), url))
-                // .collect::<Vec<Result<ScrapedRecipe, ScrapeError>>>()
-                .find_map(Result::ok)
-            {
-                Some(r) => Ok(r),
-                None => Err(ScrapeError::LDJSONMissingRecipe(url.to_string(), items)),
-            }
+                .find_map(|ld| ld_json::scrape_from_ld_json(ld.as_str(), url).ok())
+                .ok_or_else(|| ScrapeError::LDJSONMissingRecipe(url.to_string(), items))
         }
-        Err(e) => match e {
-            ScrapeError::NoLDJSON(_) => scrape_from_html(dom, url),
-            _ => Err(e),
-        },
+        Err(e) => Err(e),
     };
+
+    let res = from_ld.or_else(|ld_err| {
+        info!("ld+json scrape failed ({ld_err}); falling back to HTML");
+        scrape_from_html(dom, url)
+    });
+
     res.map(|mut r| {
         r.ingredients = r.ingredients.into_iter().map(clean_string).collect();
         r.instructions = r.instructions.into_iter().map(clean_string).collect();

--- a/recipe-scraper/tests/integration.rs
+++ b/recipe-scraper/tests/integration.rs
@@ -136,6 +136,28 @@ fn handle_no_ldjson() {
     ));
 }
 
+/// Malformed LD+JSON should gracefully fall back to HTML scraping rather than
+/// erroring. Previously only a *missing* ld+json block triggered the fallback;
+/// an unparseable one returned an error.
+#[test]
+fn malformed_ld_falls_back_to_html() {
+    let html = r#"<html><head><title>Test Recipe</title>
+<script type="application/ld+json">{ not valid json )</script>
+</head><body>
+<li class="jetpack-recipe-ingredient">1 cup flour</li>
+<li class="jetpack-recipe-ingredient">2 large eggs</li>
+<div class="jetpack-recipe-directions">Mix.
+Bake.</div>
+</body></html>"#;
+    let res = scrape(html, "https://example.com/recipe").unwrap();
+    assert_eq!(
+        res.ingredients.len(),
+        2,
+        "should recover ingredients via HTML"
+    );
+    assert!(res.ingredients[0].contains("flour"));
+}
+
 #[test]
 fn test_scrape_chefsteps() {
     let r = scrape(


### PR DESCRIPTION
Hardens the weakest crate. Three concrete bugs from the earlier audit:

1. **Graceful degradation** — `scrape()` only fell back to HTML when ld+json was *entirely missing*; a malformed/undeserializable block (or one with no recipe) errored out. Now it falls back to HTML on **any** ld+json failure. New regression test `malformed_ld_falls_back_to_html`.
2. **Panic fixes** — `ld_json.rs` indexed `d[0]` / `l[0]` / `i[0]` on instruction and image lists; empty arrays panicked. Now bounds-checked (`.first()`).
3. **User-Agent** — the fetcher sent a bare `"recipe"` UA (commonly blocked); now a descriptive browser-prefixed UA with the crate version.

Also tidied the noisy `scrape()` log line.

Left as a follow-up: schema.org **microdata** (`itemprop`) as an additional HTML strategy.

Verified: 40 scraper tests (incl. the new one), clippy `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)