### PR TITLE
ci: fix Cloudflare deploy (wasm-opt reference-types)

### DIFF
--- a/ingredient-wasm/Cargo.toml
+++ b/ingredient-wasm/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2021"
 license = "MIT"
 publish = false
 
+# Recent rustc emits WASM using reference-types/bulk-memory (e.g. multiple
+# tables). Older `wasm-opt` builds (as shipped by the CI wasm-pack) reject that
+# in MVP mode with "Only 1 table definition allowed in MVP". Enable the features
+# so wasm-opt accepts it, while keeping `-O` size optimization.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O', '--enable-reference-types', '--enable-bulk-memory']
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 


### PR DESCRIPTION
The main-only **Deploy** job started failing on `wasm-opt`: `Only 1 table definition allowed in MVP`. Recent rustc emits reference-types/bulk-memory WASM (multiple tables); the older wasm-opt from the CI wasm-pack rejects it in MVP mode (local wasm-pack 0.14 handles it fine — hence PRs/local were green and only the main deploy broke). Pass `--enable-reference-types --enable-bulk-memory` to wasm-opt, keeping `-O`. Verified local `wasm-pack build` still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)