### PR TITLE
refactor(ingredient): tidy the measurement subsystem (tests, paren dedupe, rich-text)

### DIFF
--- a/ingredient-parser/src/parser/measurement/composite.rs
+++ b/ingredient-parser/src/parser/measurement/composite.rs
@@ -14,6 +14,7 @@ use crate::parser::Res;
 use crate::traced_parser;
 use crate::unit::Measure;
 
+use super::guards::find_matching_paren;
 use super::{MeasurementParser, DEFAULT_UNIT};
 
 use crate::parser::vocab::CONTAINER_NOUNS;
@@ -91,22 +92,7 @@ impl<'a> MeasurementParser<'a> {
         // parenthesized form "(…)" or the bare hyphenated adjective "10-ounce".
         let (inner, after) = if rest.starts_with('(') {
             // Find the matching close paren (handles nesting).
-            let mut depth = 0usize;
-            let mut close = None;
-            for (i, c) in rest.char_indices() {
-                match c {
-                    '(' => depth += 1,
-                    ')' => {
-                        depth -= 1;
-                        if depth == 0 {
-                            close = Some(i);
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            let close = close.ok_or_else(reject)?;
+            let close = find_matching_paren(rest).ok_or_else(reject)?;
             (&rest[1..close], rest[close + 1..].trim_start())
         } else {
             // Bare hyphenated size adjective: "10-ounce", "1½-inch". Take the

--- a/ingredient-parser/src/parser/measurement/composite.rs
+++ b/ingredient-parser/src/parser/measurement/composite.rs
@@ -190,3 +190,93 @@ impl<'a> MeasurementParser<'a> {
         )
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::test_support::units;
+    use super::super::MeasurementParser;
+    use rstest::{fixture, rstest};
+    use std::collections::HashSet;
+
+    #[fixture]
+    fn units_fx() -> HashSet<String> {
+        units()
+    }
+
+    #[rstest]
+    #[case::single("(2 cups)", 1)]
+    #[case::multiple("(1 cup / 240 ml)", 2)]
+    fn test_parenthesized_amounts(
+        units_fx: HashSet<String>,
+        #[case] input: &str,
+        #[case] expected_count: usize,
+    ) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_parenthesized_amounts(input);
+        assert!(result.is_ok());
+        let (_, measures) = result.unwrap();
+        assert_eq!(measures.len(), expected_count);
+    }
+
+    #[rstest]
+    // Compatible kinds (volume + volume) are summed into a single measure.
+    #[case::word("1 cup plus 2 tbsp", 1)]
+    #[case::symbol("½ cup + 2 tbsp", 1)]
+    // Incompatible kinds (volume + weight) keep both rather than dropping one.
+    #[case::incompatible("1 cup plus 100 grams", 2)]
+    fn test_plus_expression(
+        units_fx: HashSet<String>,
+        #[case] input: &str,
+        #[case] expected_len: usize,
+    ) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let (_, measures) = parser.parse_plus_expression(input).unwrap();
+        assert_eq!(measures.len(), expected_len, "input: {input}");
+    }
+
+    /// A parenthetical size — hyphenated ("1-ounce") or space form ("14.5 oz") —
+    /// is hoisted into a second measure while the count keeps the container unit:
+    /// "1 (1-ounce) piece" -> [1 piece, 1 oz]; "2 (14.5 oz) cans" -> [2 can, 14.5 oz].
+    #[rstest]
+    #[case::piece("1 (1-ounce) piece ginger", 2, "piece")]
+    #[case::can("1 (28-ounce) can tomatoes", 2, "can")]
+    #[case::space_form("2 (14.5 oz) cans tomatoes", 2, "can")]
+    fn test_count_with_parenthetical_size(
+        units_fx: HashSet<String>,
+        #[case] input: &str,
+        #[case] expected_len: usize,
+        #[case] first_unit: &str,
+    ) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let (_, measures) = parser.parse_count_with_parenthetical_size(input).unwrap();
+        assert_eq!(measures.len(), expected_len, "input: {input}");
+        assert_eq!(measures[0].unit_as_string(), first_unit);
+        assert_eq!(measures[1].unit_as_string(), "oz");
+    }
+
+    /// Count + parenthetical/hyphenated size with NO container noun: the count
+    /// becomes a "whole" amount and the size a second amount, e.g.
+    /// "1 (3 ounce) chicken" -> [1 whole, 3 oz] and "One 6-ounce carrot" ->
+    /// [1 whole, 6 oz]. (With a container the first unit is the container.)
+    #[rstest]
+    #[case::paren("1 (3 ounce) chicken")]
+    #[case::hyphen("One 6-ounce carrot")]
+    fn test_count_with_size_no_container(units_fx: HashSet<String>, #[case] input: &str) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let (_, measures) = parser.parse_count_with_parenthetical_size(input).unwrap();
+        assert_eq!(measures.len(), 2, "input: {input}");
+        assert_eq!(measures[0].unit_as_string(), "whole");
+        assert_eq!(measures[1].unit_as_string(), "oz");
+    }
+
+    /// A parenthetical that is NOT a size (no parseable measurement inside) is
+    /// rejected even when a container noun follows.
+    #[rstest]
+    fn test_parenthetical_size_rejects_non_size(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        assert!(parser
+            .parse_count_with_parenthetical_size("1 (not defrosted) can tomatoes")
+            .is_err());
+    }
+}

--- a/ingredient-parser/src/parser/measurement/guards.rs
+++ b/ingredient-parser/src/parser/measurement/guards.rs
@@ -141,4 +141,57 @@ mod tests {
     fn test_find_matching_paren(#[case] input: &str, #[case] expected: Option<usize>) {
         assert_eq!(find_matching_paren(input), expected, "input: {input}");
     }
+
+    #[rstest]
+    #[case::period(".")]
+    #[case::of(" of")]
+    #[case::something("something")]
+    fn test_optional_period_or_of(#[case] input: &str) {
+        let result = optional_period_or_of(input);
+        assert!(result.is_ok());
+    }
+
+    #[rstest]
+    #[case::inch("-inch", true, "basic inch")]
+    #[case::inches("-inches", true, "plural inches")]
+    #[case::cm("-cm", true, "basic cm")]
+    #[case::centimeter("-centimeter", true, "full centimeter")]
+    #[case::centimeters("-centimeters", true, "plural centimeters")]
+    #[case::mm("-mm", true, "basic mm")]
+    #[case::foot("-foot", true, "basic foot")]
+    #[case::feet("-feet", false, "irregular plural feet (not detected)")] // feet is irregular, not handled
+    #[case::meter("-meter", true, "basic meter")]
+    #[case::meters("-meters", true, "plural meters")]
+    #[case::inch_piece("-inch piece", true, "inch with trailing text")]
+    #[case::not_dimension("-ish", false, "not a dimension")]
+    #[case::empty("-", false, "just hyphen")]
+    #[case::no_hyphen("inch", false, "no leading hyphen")]
+    #[case::yard("-yard", true, "basic yard")]
+    #[case::yards("-yards", true, "plural yards")]
+    fn test_dimension_suffix_detection(
+        #[case] input: &str,
+        #[case] expected: bool,
+        #[case] _desc: &str,
+    ) {
+        assert_eq!(
+            starts_with_dimension_suffix(input),
+            expected,
+            "Failed for input: {input}"
+        );
+    }
+
+    #[rstest]
+    #[case::inch("inch", true)]
+    #[case::inches("inches", true)]
+    #[case::cm("cm", true)]
+    #[case::mm("mm", true)]
+    #[case::foot("foot", true)]
+    #[case::ft("ft", true)]
+    #[case::meter("meter", true)]
+    #[case::meters("meters", true)]
+    #[case::cup("cup", false)]
+    #[case::tsp("tsp", false)]
+    fn test_is_distance_unit(#[case] input: &str, #[case] expected: bool) {
+        assert_eq!(is_distance_unit(input), expected, "Failed for: {input}");
+    }
 }

--- a/ingredient-parser/src/parser/measurement/guards.rs
+++ b/ingredient-parser/src/parser/measurement/guards.rs
@@ -28,6 +28,29 @@ pub(super) fn optional_article(input: &str) -> Res<&str, Option<&str>> {
     .parse(input)
 }
 
+/// Given a string whose first `(` opens a (possibly nested) group, return the
+/// byte index of the matching `)`. Returns `None` if there is no `(` or the
+/// parentheses are unbalanced. Used to skip over a parenthesized aside while
+/// respecting nesting (e.g. the size in "1 (1½-inch) piece" or a unit after a
+/// description).
+pub(super) fn find_matching_paren(input: &str) -> Option<usize> {
+    let open = input.find('(')?;
+    let mut depth = 0usize;
+    for (index, character) in input[open..].char_indices() {
+        match character {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(open + index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Check if a bare number looks like a step number in instructions.
 ///
 /// Returns true if the remaining input starts with whitespace followed by
@@ -102,4 +125,20 @@ pub(crate) fn is_distance_unit(s: &str) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::simple("(abc) rest", Some(4))]
+    #[case::nested("(a (b) c) rest", Some(8))]
+    #[case::leading_text("x (a) b", Some(4))]
+    #[case::no_open("no parens", None)]
+    #[case::unbalanced("(a (b)", None)]
+    fn test_find_matching_paren(#[case] input: &str, #[case] expected: Option<usize>) {
+        assert_eq!(find_matching_paren(input), expected, "input: {input}");
+    }
 }

--- a/ingredient-parser/src/parser/measurement/mod.rs
+++ b/ingredient-parser/src/parser/measurement/mod.rs
@@ -36,8 +36,44 @@ use crate::traced_parser;
 use crate::unit::Measure;
 
 use self::guards::optional_period_or_of;
+
+/// Shared test fixture data for the measurement submodules' co-located tests.
 #[cfg(test)]
-use self::guards::{is_distance_unit, starts_with_dimension_suffix};
+pub(crate) mod test_support {
+    use std::collections::HashSet;
+
+    /// The unit set used across measurement tests.
+    pub(crate) fn units() -> HashSet<String> {
+        [
+            "cup",
+            "cups",
+            "tbsp",
+            "tsp",
+            "gram",
+            "grams",
+            "g",
+            "whole",
+            "lb",
+            "oz",
+            "ml",
+            "tablespoon",
+            "tablespoons",
+            "teaspoon",
+            "teaspoons",
+            "slice",
+            "slices",
+            "ounce",
+            "ounces",
+            "piece",
+            "pieces",
+            "can",
+            "cans",
+        ]
+        .iter()
+        .map(|&s| s.to_string())
+        .collect()
+    }
+}
 
 /// Default unit for amounts without a specified unit (e.g., "2 eggs")
 pub(super) const DEFAULT_UNIT: &str = "whole";
@@ -147,48 +183,18 @@ impl<'a> MeasurementParser<'a> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
+    use super::test_support::units;
     use super::*;
     use rstest::{fixture, rstest};
 
     #[fixture]
-    fn units() -> HashSet<String> {
-        [
-            "cup",
-            "cups",
-            "tbsp",
-            "tsp",
-            "gram",
-            "grams",
-            "g",
-            "whole",
-            "lb",
-            "oz",
-            "ml",
-            "tablespoon",
-            "tablespoons",
-            "teaspoon",
-            "teaspoons",
-            "slice",
-            "slices",
-            "ounce",
-            "ounces",
-            "piece",
-            "pieces",
-            "can",
-            "cans",
-        ]
-        .iter()
-        .map(|&s| s.to_string())
-        .collect()
+    fn units_fx() -> HashSet<String> {
+        units()
     }
 
-    // ============================================================================
-    // Basic Measurement Tests
-    // ============================================================================
-
     #[rstest]
-    fn test_measurement_parser(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
+    fn test_measurement_parser(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
         let result = parser.parse_measurement_list("2 cups");
         assert!(result.is_ok());
         let (remaining, measures) = result.unwrap();
@@ -196,61 +202,18 @@ mod tests {
         assert_eq!(measures.len(), 1);
     }
 
-    // ============================================================================
-    // Range Format Tests
-    // ============================================================================
-
     #[rstest]
     #[case::hyphen("2-3 cups")]
     #[case::to("2 to 3 cups")]
     #[case::through("2 through 3 cups")]
     #[case::or("2 or 3 cups")]
-    fn test_range_formats(units: HashSet<String>, #[case] input: &str) {
-        let parser = MeasurementParser::new(&units, false);
+    fn test_range_formats(units_fx: HashSet<String>, #[case] input: &str) {
+        let parser = MeasurementParser::new(&units_fx, false);
         let result = parser.parse_measurement_list(input);
         assert!(result.is_ok(), "Failed to parse: {input}");
         let (_, measures) = result.unwrap();
         assert!(!measures.is_empty());
     }
-
-    // ============================================================================
-    // Parenthesized Amounts Tests
-    // ============================================================================
-
-    #[rstest]
-    #[case::single("(2 cups)", 1)]
-    #[case::multiple("(1 cup / 240 ml)", 2)]
-    fn test_parenthesized_amounts(
-        units: HashSet<String>,
-        #[case] input: &str,
-        #[case] expected_count: usize,
-    ) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_parenthesized_amounts(input);
-        assert!(result.is_ok());
-        let (_, measures) = result.unwrap();
-        assert_eq!(measures.len(), expected_count);
-    }
-
-    // ============================================================================
-    // Upper Bound Tests
-    // ============================================================================
-
-    #[rstest]
-    #[case::up_to("up to 5", 5.0)]
-    #[case::at_most("at most 10", 10.0)]
-    fn test_upper_bound_only(units: HashSet<String>, #[case] input: &str, #[case] expected: f64) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_upper_bound_only(input);
-        assert!(result.is_ok());
-        let (_, (lower, upper)) = result.unwrap();
-        assert_eq!(lower, 0.0);
-        assert_eq!(upper, Some(expected));
-    }
-
-    // ============================================================================
-    // Separator Tests
-    // ============================================================================
 
     #[rstest]
     #[case::semicolon("2 cups; 1 tbsp", 2)]
@@ -259,284 +222,25 @@ mod tests {
     #[case::pipe("150 grams | 1 cup", 2)]
     #[case::multiplication_sign("1 × 400 grams", 2)]
     fn test_measurement_list_separators(
-        units: HashSet<String>,
+        units_fx: HashSet<String>,
         #[case] input: &str,
         #[case] expected_count: usize,
     ) {
-        let parser = MeasurementParser::new(&units, false);
+        let parser = MeasurementParser::new(&units_fx, false);
         let result = parser.parse_measurement_list(input);
         assert!(result.is_ok());
         let (_, measures) = result.unwrap();
         assert_eq!(measures.len(), expected_count);
     }
 
-    // ============================================================================
-    // Rich Text Mode Tests
-    // ============================================================================
-
-    #[rstest]
-    #[case::decimal("2.5", 2.5)]
-    #[case::fraction("1/2", 0.5)]
-    #[case::unicode_fraction("½", 0.5)]
-    fn test_rich_text_mode(units: HashSet<String>, #[case] input: &str, #[case] expected: f64) {
-        let parser = MeasurementParser::new(&units, true);
-        let result = parser.parse_number(input);
-        assert!(result.is_ok());
-        let (_, val) = result.unwrap();
-        assert!((val - expected).abs() < 0.001);
-    }
-
-    // ============================================================================
-    // optional_period_or_of Tests
-    // ============================================================================
-
-    #[rstest]
-    #[case::period(".")]
-    #[case::of(" of")]
-    #[case::something("something")]
-    fn test_optional_period_or_of(#[case] input: &str) {
-        let result = optional_period_or_of(input);
-        assert!(result.is_ok());
-    }
-
-    // ============================================================================
-    // Other Tests
-    // ============================================================================
-
-    #[rstest]
-    // Compatible kinds (volume + volume) are summed into a single measure.
-    #[case::word("1 cup plus 2 tbsp", 1)]
-    #[case::symbol("½ cup + 2 tbsp", 1)]
-    // Incompatible kinds (volume + weight) keep both rather than dropping one.
-    #[case::incompatible("1 cup plus 100 grams", 2)]
-    fn test_plus_expression(
-        units: HashSet<String>,
-        #[case] input: &str,
-        #[case] expected_len: usize,
-    ) {
-        let parser = MeasurementParser::new(&units, false);
-        let (_, measures) = parser.parse_plus_expression(input).unwrap();
-        assert_eq!(measures.len(), expected_len, "input: {input}");
-    }
-
-    #[rstest]
-    fn test_multiplier(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_multiplier("2 x ");
-        assert!(result.is_ok());
-        let (_, mult) = result.unwrap();
-        assert_eq!(mult, 2.0);
-    }
-
-    #[rstest]
-    fn test_measurement_with_about(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_single_measurement("about 2 cups");
-        assert!(result.is_ok());
-    }
-
-    /// Leading approximation qualifiers (any case, optional article) are skipped
-    /// so the amount after them still parses.
-    #[rstest]
-    #[case::lower_about("about 2 cups")]
-    #[case::cap_about("About 2 cups")]
-    #[case::generous("Generous 1 cup")]
-    #[case::scant("Scant 1 cup")]
-    #[case::heaping("Heaping 1 tablespoon")]
-    #[case::article("A generous 1 cup")]
-    fn test_leading_qualifiers(units: HashSet<String>, #[case] input: &str) {
-        let parser = MeasurementParser::new(&units, false);
-        let (_, measure) = parser.parse_single_measurement(input).unwrap();
-        // The qualifier is discarded; the numeric value survives.
-        assert!(measure.value() >= 1.0, "input: {input}");
-    }
-
-    /// A parenthetical size — hyphenated ("1-ounce") or space form ("14.5 oz") —
-    /// is hoisted into a second measure while the count keeps the container unit:
-    /// "1 (1-ounce) piece" -> [1 piece, 1 oz]; "2 (14.5 oz) cans" -> [2 can, 14.5 oz].
-    #[rstest]
-    #[case::piece("1 (1-ounce) piece ginger", 2, "piece")]
-    #[case::can("1 (28-ounce) can tomatoes", 2, "can")]
-    #[case::space_form("2 (14.5 oz) cans tomatoes", 2, "can")]
-    fn test_count_with_parenthetical_size(
-        units: HashSet<String>,
-        #[case] input: &str,
-        #[case] expected_len: usize,
-        #[case] first_unit: &str,
-    ) {
-        let parser = MeasurementParser::new(&units, false);
-        let (_, measures) = parser.parse_count_with_parenthetical_size(input).unwrap();
-        assert_eq!(measures.len(), expected_len, "input: {input}");
-        assert_eq!(measures[0].unit_as_string(), first_unit);
-        assert_eq!(measures[1].unit_as_string(), "oz");
-    }
-
-    /// Count + parenthetical/hyphenated size with NO container noun: the count
-    /// becomes a "whole" amount and the size a second amount, e.g.
-    /// "1 (3 ounce) chicken" -> [1 whole, 3 oz] and "One 6-ounce carrot" ->
-    /// [1 whole, 6 oz]. (With a container the first unit is the container; see
-    /// the test above.)
-    #[rstest]
-    #[case::paren("1 (3 ounce) chicken")]
-    #[case::hyphen("One 6-ounce carrot")]
-    fn test_count_with_size_no_container(units: HashSet<String>, #[case] input: &str) {
-        let parser = MeasurementParser::new(&units, false);
-        let (_, measures) = parser.parse_count_with_parenthetical_size(input).unwrap();
-        assert_eq!(measures.len(), 2, "input: {input}");
-        assert_eq!(measures[0].unit_as_string(), "whole");
-        assert_eq!(measures[1].unit_as_string(), "oz");
-    }
-
-    /// A cross-unit range "2 tsp to 2 tbsp" yields two separate amounts (it can't
-    /// fold into one ranged Measure); a same-unit range falls through so the
-    /// range parser keeps it as a single Measure with an upper bound.
-    #[rstest]
-    fn test_cross_unit_range(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let (_, measures) = parser
-            .parse_cross_unit_range("2 teaspoons to 2 tablespoons")
-            .unwrap();
-        assert_eq!(measures.len(), 2);
-        assert_eq!(measures[0].unit_as_string(), "tsp");
-        assert_eq!(measures[1].unit_as_string(), "tbsp");
-        // Same unit on both sides → not a cross-unit range.
-        assert!(parser.parse_cross_unit_range("2 cups to 3 cups").is_err());
-    }
-
-    /// A parenthetical that is NOT a size (no parseable measurement inside) is
-    /// rejected even when a container noun follows, so it falls through to the
-    /// plain parenthesized-amount / name paths.
-    #[rstest]
-    fn test_parenthetical_size_rejects_non_size(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        assert!(parser
-            .parse_count_with_parenthetical_size("1 (not defrosted) can tomatoes")
-            .is_err());
-    }
-
-    #[rstest]
-    fn test_unit_only(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_unit_only(" cup ");
-        assert!(result.is_ok());
-        let (_, measure) = result.unwrap();
-        assert_eq!(measure.value(), 1.0);
-    }
-
-    #[rstest]
-    fn test_unit_only_rejected_in_rich_text_mode(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, true);
-        assert!(parser.parse_unit_only(" cup ").is_err());
-    }
-
-    /// Test that unit mismatch in ranges returns None
-    /// Note: This only works for dash-style ranges where both units are adjacent to numbers
-    /// (e.g., "1g-2tbsp"). Word-style ranges like "1 cup to 2 tbsp" don't detect mismatch
-    /// because the space before the second unit prevents it from being parsed.
-    #[rstest]
-    #[case::dash_mismatch("1g-2tbsp")]
-    fn test_range_unit_mismatch(units: HashSet<String>, #[case] input: &str) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_range_with_units(input);
-        assert!(result.is_ok(), "Failed to parse: {input}");
-        let (remaining, opt_measure) = result.unwrap();
-        assert!(
-            opt_measure.is_none(),
-            "Expected None for unit mismatch on '{input}', got {opt_measure:?}, remaining: '{remaining}'",
-        );
-    }
-
-    #[rstest]
-    fn test_em_dash_range(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_range_end("–3");
-        assert!(result.is_ok());
-        let (_, upper) = result.unwrap();
-        assert_eq!(upper, 3.0);
-    }
-
-    #[rstest]
-    fn test_no_unit_defaults_to_whole(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_single_measurement("2 ");
-        assert!(result.is_ok());
-        let (_, measure) = result.unwrap();
-        let measure_str = format!("{measure}");
-        assert!(measure_str.contains("whole") || measure.value() == 2.0);
-    }
-
     #[rstest]
     #[case::step_number("1 Bring a pot of water to a boil.")]
     #[case::numbered_instruction("2 Set out 4 ramen bowls.")]
-    fn test_step_numbers_not_parsed_as_measurements(units: HashSet<String>, #[case] input: &str) {
-        let parser = MeasurementParser::new(&units, true);
-        assert!(parser.parse_measurement_list(input).is_err());
-    }
-
-    #[rstest]
-    #[case::inch_piece("1-inch piece ginger")]
-    #[case::cm_piece("2-cm knob ginger")]
-    fn test_dimension_suffix_rejected(units: HashSet<String>, #[case] input: &str) {
-        let parser = MeasurementParser::new(&units, true);
-        assert!(parser.parse_single_measurement(input).is_err());
-    }
-
-    #[rstest]
-    fn test_unit_after_parenthesized_description(units: HashSet<String>) {
-        let parser = MeasurementParser::new(&units, false);
-        let result = parser.parse_single_measurement("4 (13-millimeter/½-inch) slices CHASHU");
-        assert!(result.is_ok());
-        let (remaining, measure) = result.unwrap();
-        assert_eq!(remaining, " CHASHU");
-        assert_eq!(measure.value(), 4.0);
-        assert_eq!(measure.unit_as_string(), "slice");
-    }
-
-    // ============================================================================
-    // Dimension Suffix Detection Tests
-    // ============================================================================
-
-    #[rstest]
-    #[case::inch("-inch", true, "basic inch")]
-    #[case::inches("-inches", true, "plural inches")]
-    #[case::cm("-cm", true, "basic cm")]
-    #[case::centimeter("-centimeter", true, "full centimeter")]
-    #[case::centimeters("-centimeters", true, "plural centimeters")]
-    #[case::mm("-mm", true, "basic mm")]
-    #[case::foot("-foot", true, "basic foot")]
-    #[case::feet("-feet", false, "irregular plural feet (not detected)")] // feet is irregular, not handled
-    #[case::meter("-meter", true, "basic meter")]
-    #[case::meters("-meters", true, "plural meters")]
-    #[case::inch_piece("-inch piece", true, "inch with trailing text")]
-    #[case::not_dimension("-ish", false, "not a dimension")]
-    #[case::empty("-", false, "just hyphen")]
-    #[case::no_hyphen("inch", false, "no leading hyphen")]
-    #[case::yard("-yard", true, "basic yard")]
-    #[case::yards("-yards", true, "plural yards")]
-    fn test_dimension_suffix_detection(
+    fn test_step_numbers_not_parsed_as_measurements(
+        units_fx: HashSet<String>,
         #[case] input: &str,
-        #[case] expected: bool,
-        #[case] _desc: &str,
     ) {
-        assert_eq!(
-            starts_with_dimension_suffix(input),
-            expected,
-            "Failed for input: {input}"
-        );
-    }
-
-    #[rstest]
-    #[case::inch("inch", true)]
-    #[case::inches("inches", true)]
-    #[case::cm("cm", true)]
-    #[case::mm("mm", true)]
-    #[case::foot("foot", true)]
-    #[case::ft("ft", true)]
-    #[case::meter("meter", true)]
-    #[case::meters("meters", true)]
-    #[case::cup("cup", false)]
-    #[case::tsp("tsp", false)]
-    fn test_is_distance_unit(#[case] input: &str, #[case] expected: bool) {
-        assert_eq!(is_distance_unit(input), expected, "Failed for: {input}");
+        let parser = MeasurementParser::new(&units_fx, true);
+        assert!(parser.parse_measurement_list(input).is_err());
     }
 }

--- a/ingredient-parser/src/parser/measurement/mod.rs
+++ b/ingredient-parser/src/parser/measurement/mod.rs
@@ -2,6 +2,24 @@
 //!
 //! This module contains all the parsers for extracting measurements from ingredient
 //! strings, including single measurements, ranges, and combined expressions.
+//!
+//! ## Rich-text mode (`is_rich_text`)
+//!
+//! The same parsers serve two modes, selected by the `is_rich_text` flag on
+//! [`MeasurementParser`]: **ingredient-list** mode (the default — "2 cups flour")
+//! and **rich-text/prose** mode (measurements embedded in instructions — "cook for
+//! 30 minutes"). The modes share ~90% of the logic; prose mode only adds a few
+//! *rejections* so noise isn't mistaken for a quantity. Every fork point:
+//!
+//! - `number::parse_number` — prose mode excludes spelled-out text numbers
+//!   ("one", "a") so words like "a pinch" or "one more" aren't read as counts.
+//! - `single::rejected_in_rich_text` — prose mode rejects step numbers
+//!   ("1. Bring…") and dimension suffixes ("1-inch piece"). See that method.
+//! - `single::parse_unit_only` — disabled entirely in prose (a bare unit like
+//!   "cup" in prose is a noun, not "1 cup"); only fires in ingredient-list mode.
+//!
+//! (Secondary-amount extraction in `refine` deliberately parses its parenthetical
+//! in ingredient-list mode regardless — "(about 2 cups)" is always a quantity.)
 
 mod composite;
 pub(crate) mod guards;

--- a/ingredient-parser/src/parser/measurement/number.rs
+++ b/ingredient-parser/src/parser/measurement/number.rs
@@ -185,3 +185,54 @@ impl<'a> MeasurementParser<'a> {
         )
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::test_support::units;
+    use super::super::MeasurementParser;
+    use rstest::{fixture, rstest};
+    use std::collections::HashSet;
+
+    #[fixture]
+    fn units_fx() -> HashSet<String> {
+        units()
+    }
+
+    #[rstest]
+    #[case::up_to("up to 5", 5.0)]
+    #[case::at_most("at most 10", 10.0)]
+    fn test_upper_bound_only(
+        units_fx: HashSet<String>,
+        #[case] input: &str,
+        #[case] expected: f64,
+    ) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_upper_bound_only(input);
+        assert!(result.is_ok());
+        let (_, (lower, upper)) = result.unwrap();
+        assert_eq!(lower, 0.0);
+        assert_eq!(upper, Some(expected));
+    }
+
+    #[rstest]
+    #[case::decimal("2.5", 2.5)]
+    #[case::fraction("1/2", 0.5)]
+    #[case::unicode_fraction("½", 0.5)]
+    fn test_rich_text_mode(units_fx: HashSet<String>, #[case] input: &str, #[case] expected: f64) {
+        let parser = MeasurementParser::new(&units_fx, true);
+        let result = parser.parse_number(input);
+        assert!(result.is_ok());
+        let (_, val) = result.unwrap();
+        assert!((val - expected).abs() < 0.001);
+    }
+
+    #[rstest]
+    fn test_multiplier(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_multiplier("2 x ");
+        assert!(result.is_ok());
+        let (_, mult) = result.unwrap();
+        assert_eq!(mult, 2.0);
+    }
+}

--- a/ingredient-parser/src/parser/measurement/range.rs
+++ b/ingredient-parser/src/parser/measurement/range.rs
@@ -160,3 +160,57 @@ impl<'a> MeasurementParser<'a> {
         )
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::test_support::units;
+    use super::super::MeasurementParser;
+    use rstest::{fixture, rstest};
+    use std::collections::HashSet;
+
+    #[fixture]
+    fn units_fx() -> HashSet<String> {
+        units()
+    }
+
+    /// A cross-unit range "2 tsp to 2 tbsp" yields two separate amounts (it can't
+    /// fold into one ranged Measure); a same-unit range falls through.
+    #[rstest]
+    fn test_cross_unit_range(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let (_, measures) = parser
+            .parse_cross_unit_range("2 teaspoons to 2 tablespoons")
+            .unwrap();
+        assert_eq!(measures.len(), 2);
+        assert_eq!(measures[0].unit_as_string(), "tsp");
+        assert_eq!(measures[1].unit_as_string(), "tbsp");
+        // Same unit on both sides → not a cross-unit range.
+        assert!(parser.parse_cross_unit_range("2 cups to 3 cups").is_err());
+    }
+
+    /// Unit mismatch in dash-style ranges returns None (e.g. "1g-2tbsp"). Word-style
+    /// ranges like "1 cup to 2 tbsp" don't detect mismatch because the space before
+    /// the second unit prevents it from being parsed.
+    #[rstest]
+    #[case::dash_mismatch("1g-2tbsp")]
+    fn test_range_unit_mismatch(units_fx: HashSet<String>, #[case] input: &str) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_range_with_units(input);
+        assert!(result.is_ok(), "Failed to parse: {input}");
+        let (remaining, opt_measure) = result.unwrap();
+        assert!(
+            opt_measure.is_none(),
+            "Expected None for unit mismatch on '{input}', got {opt_measure:?}, remaining: '{remaining}'",
+        );
+    }
+
+    #[rstest]
+    fn test_em_dash_range(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_range_end("–3");
+        assert!(result.is_ok());
+        let (_, upper) = result.unwrap();
+        assert_eq!(upper, 3.0);
+    }
+}

--- a/ingredient-parser/src/parser/measurement/single.rs
+++ b/ingredient-parser/src/parser/measurement/single.rs
@@ -16,8 +16,8 @@ use crate::traced_parser;
 use crate::unit::{self, Measure};
 
 use super::guards::{
-    is_distance_unit, looks_like_step_number, optional_article, optional_dash_separator,
-    optional_period_or_of, starts_with_dimension_suffix,
+    find_matching_paren, is_distance_unit, looks_like_step_number, optional_article,
+    optional_dash_separator, optional_period_or_of, starts_with_dimension_suffix,
 };
 use super::{MeasurementParser, DEFAULT_UNIT};
 
@@ -145,23 +145,7 @@ impl<'a> MeasurementParser<'a> {
             return None;
         }
 
-        let mut depth = 0;
-        let mut close_pos = None;
-        for (index, character) in input.char_indices() {
-            match character {
-                '(' => depth += 1,
-                ')' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        close_pos = Some(index);
-                        break;
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        let close_pos = close_pos?;
+        let close_pos = find_matching_paren(input)?;
         let after_paren = input[close_pos + 1..].trim_start();
         let Ok((remaining, unit)) = self.unit(after_paren) else {
             return None;

--- a/ingredient-parser/src/parser/measurement/single.rs
+++ b/ingredient-parser/src/parser/measurement/single.rs
@@ -327,3 +327,84 @@ pub(crate) fn leading_qualifier(input: &str) -> Res<&str, ()> {
     let (input, _) = space1(input)?;
     Ok((input, ()))
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::test_support::units;
+    use super::super::MeasurementParser;
+    use rstest::{fixture, rstest};
+    use std::collections::HashSet;
+
+    #[fixture]
+    fn units_fx() -> HashSet<String> {
+        units()
+    }
+
+    #[rstest]
+    fn test_measurement_with_about(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_single_measurement("about 2 cups");
+        assert!(result.is_ok());
+    }
+
+    /// Leading approximation qualifiers (any case, optional article) are skipped
+    /// so the amount after them still parses.
+    #[rstest]
+    #[case::lower_about("about 2 cups")]
+    #[case::cap_about("About 2 cups")]
+    #[case::generous("Generous 1 cup")]
+    #[case::scant("Scant 1 cup")]
+    #[case::heaping("Heaping 1 tablespoon")]
+    #[case::article("A generous 1 cup")]
+    fn test_leading_qualifiers(units_fx: HashSet<String>, #[case] input: &str) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let (_, measure) = parser.parse_single_measurement(input).unwrap();
+        // The qualifier is discarded; the numeric value survives.
+        assert!(measure.value() >= 1.0, "input: {input}");
+    }
+
+    #[rstest]
+    fn test_unit_only(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_unit_only(" cup ");
+        assert!(result.is_ok());
+        let (_, measure) = result.unwrap();
+        assert_eq!(measure.value(), 1.0);
+    }
+
+    #[rstest]
+    fn test_unit_only_rejected_in_rich_text_mode(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, true);
+        assert!(parser.parse_unit_only(" cup ").is_err());
+    }
+
+    #[rstest]
+    fn test_no_unit_defaults_to_whole(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_single_measurement("2 ");
+        assert!(result.is_ok());
+        let (_, measure) = result.unwrap();
+        let measure_str = format!("{measure}");
+        assert!(measure_str.contains("whole") || measure.value() == 2.0);
+    }
+
+    #[rstest]
+    #[case::inch_piece("1-inch piece ginger")]
+    #[case::cm_piece("2-cm knob ginger")]
+    fn test_dimension_suffix_rejected(units_fx: HashSet<String>, #[case] input: &str) {
+        let parser = MeasurementParser::new(&units_fx, true);
+        assert!(parser.parse_single_measurement(input).is_err());
+    }
+
+    #[rstest]
+    fn test_unit_after_parenthesized_description(units_fx: HashSet<String>) {
+        let parser = MeasurementParser::new(&units_fx, false);
+        let result = parser.parse_single_measurement("4 (13-millimeter/½-inch) slices CHASHU");
+        assert!(result.is_ok());
+        let (remaining, measure) = result.unwrap();
+        assert_eq!(remaining, " CHASHU");
+        assert_eq!(measure.value(), 4.0);
+        assert_eq!(measure.unit_as_string(), "slice");
+    }
+}

--- a/ingredient-parser/src/parser/measurement/single.rs
+++ b/ingredient-parser/src/parser/measurement/single.rs
@@ -76,6 +76,20 @@ impl<'a> MeasurementParser<'a> {
         )
     }
 
+    /// In rich-text (prose) mode, reject a bare number whose continuation is not
+    /// actually a quantity. Two cases (no-op outside rich-text mode):
+    /// - a **step number**: "1. Bring a pot…" — a numbered instruction, not "1 of X".
+    ///   (Only when no measurement-ending period was consumed.)
+    /// - a **dimension suffix**: "1-inch piece ginger" — "1-inch" is descriptive in
+    ///   prose, whereas in ingredient-list mode the dimension IS the amount (→ 1").
+    fn rejected_in_rich_text(&self, next_input: &str, period_consumed: Option<&str>) -> bool {
+        if !self.is_rich_text {
+            return false;
+        }
+        (period_consumed.is_none() && looks_like_step_number(next_input))
+            || starts_with_dimension_suffix(next_input)
+    }
+
     fn resolve_single_measurement_unit<'b>(
         &self,
         input: &'b str,
@@ -91,15 +105,7 @@ impl<'a> MeasurementParser<'a> {
             return Ok((after_paren, unit));
         }
 
-        if self.is_rich_text && period_consumed.is_none() && looks_like_step_number(next_input) {
-            return Err(reject_measurement(input));
-        }
-
-        // In rich text (prose), a hyphenated dimension like "1-inch" in
-        // "1-inch piece ginger" is descriptive, not a quantity, so reject it. In
-        // ingredient-list mode the dimension IS the amount (e.g. "2-inch piece
-        // ginger" → 2"), parsed below by parse_dimension_unit.
-        if self.is_rich_text && starts_with_dimension_suffix(next_input) {
+        if self.rejected_in_rich_text(next_input, period_consumed) {
             return Err(reject_measurement(input));
         }
 


### PR DESCRIPTION
Small, behavior-preserving cleanup of the measurement subsystem — the part the previous pipeline refactor (PR #321) left untouched. Three low-risk wins; deliberately **not** doing the vocab-list consolidation, a Vocab-struct rewrite, or de-regexing the refine passes (churn / regression-risk for aesthetic-only payoff).

No parse behavior changes — corpus and all snapshots are byte-identical. 688 ingredient tests / 785 workspace, clippy `-D warnings` clean.

## Changes
1. **Co-locate measurement tests** — `mod.rs` was ~76% tests exercising functions defined in the *sibling* submodules (which had zero internal tests). Each test now lives in the submodule that owns its function (`single`/`range`/`composite`/`number`/`guards`); `mod.rs` keeps only the `parse_measurement_list`/separator/dispatch tests. Shared `units()` fixture via a `#[cfg(test)] test_support` module. `mod.rs`: 524 → 246 lines.
2. **`find_matching_paren` helper** — replaced two identical `char_indices` paren-depth loops (`single.rs`, `composite.rs`) with one tested `guards::find_matching_paren`.
3. **`is_rich_text` consolidate + document** — grouped `single.rs`'s scattered rich-text rejections into one named `rejected_in_rich_text` predicate, and added a module doc to `measurement/mod.rs` enumerating every `is_rich_text` fork point and why. Flag kept (the modes share ~90% of primitives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)