### PR TITLE
Grammar decomposition view: parser API → CLI --explain → demo site

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +550,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +679,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -904,7 +943,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1861,10 +1900,13 @@ dependencies = [
  "futures",
  "ingredient",
  "maud",
+ "miette",
  "open",
  "recipe-epub",
  "recipe-scraper-fetcher",
+ "rstest",
  "serde_json",
+ "tabled",
  "tokio",
 ]
 
@@ -2043,7 +2085,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2088,6 +2130,12 @@ dependencies = [
  "wasip3",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gl_generator"
@@ -2708,6 +2756,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,6 +3048,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3527,6 +3611,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3600,6 +3693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,6 +3706,17 @@ checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "papergrid"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -4570,6 +4680,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5164,6 +5280,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5216,6 +5353,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5245,6 +5406,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -5669,10 +5859,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ rstest = "0.26"
 thiserror = "2.0"
 futures = "0.3.32"
 dotenvy = "0.15"
+miette = { version = "7", features = ["fancy"] }
+tabled = "0.21"
 ingredient = { path = "ingredient-parser" }
 recipe-types = { path = "recipe-types" }
 recipe-scraper = { path = "recipe-scraper" }

--- a/demo-site/src/DecompositionView.tsx
+++ b/demo-site/src/DecompositionView.tsx
@@ -1,0 +1,80 @@
+import type { WDecomposition, WField } from "./wasm";
+
+// Each grammar field gets an underline + legend dot color. `amount` matches the
+// rich-text measure highlight (blue), `name` the existing name underline
+// (accent/emerald), `modifier` a distinct amber.
+const FIELD_STYLES: Record<
+  WField,
+  { underline: string; dot: string; label: string }
+> = {
+  amount: { underline: "border-blue-400", dot: "bg-blue-400", label: "amount" },
+  name: { underline: "border-accent-400", dot: "bg-accent-400", label: "name" },
+  modifier: {
+    underline: "border-amber-400",
+    dot: "bg-amber-400",
+    label: "modifier",
+  },
+};
+
+const FIELD_ORDER: WField[] = ["amount", "name", "modifier"];
+
+/**
+ * Diagnostic-style view of how the grammar carved the line: the (normalized)
+ * source in monospace with a colored underline under each amount/name/modifier
+ * span, plus a legend. Mirrors `parse-ingredient --explain`. Renders nothing
+ * until there's input.
+ */
+export function DecompositionView({
+  decomp,
+}: {
+  decomp: WDecomposition | undefined;
+}) {
+  if (!decomp) return null;
+
+  const present = FIELD_ORDER.filter((f) =>
+    decomp.segments.some((s) => s.field === f)
+  );
+
+  return (
+    <div className="mb-5">
+      <div className="mb-2 text-sm font-medium text-zinc-500">
+        How the grammar carved it
+      </div>
+      <div className="overflow-x-auto rounded-lg border border-zinc-200 bg-zinc-50 px-4 py-3">
+        <div className="font-mono text-base whitespace-pre text-zinc-900">
+          {decomp.segments.map((seg, i) =>
+            seg.field ? (
+              <span
+                key={i}
+                className={`border-b-2 pb-0.5 ${FIELD_STYLES[seg.field].underline}`}
+              >
+                {seg.text}
+              </span>
+            ) : (
+              <span key={i} className="text-zinc-400">
+                {seg.text}
+              </span>
+            )
+          )}
+        </div>
+      </div>
+      {present.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-3 text-xs text-zinc-500">
+          {present.map((f) => (
+            <span key={f} className="inline-flex items-center gap-1.5">
+              <span
+                className={`h-2 w-2 rounded-full ${FIELD_STYLES[f].dot}`}
+              />
+              {FIELD_STYLES[f].label}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-xs text-zinc-400">
+          No grammar decomposition — handled by a recognizer or name-only
+          fallback.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/demo-site/src/Demo.tsx
+++ b/demo-site/src/Demo.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { RichItem, wasm, ScrapedRecipe, Measure } from "./wasm";
 import { Spinner } from "./Spinner";
+import { DecompositionView } from "./DecompositionView";
 
 /* ── URL state helpers ─────────────────────────────────────────
    Inputs are persisted to the query string so demo links are
@@ -81,6 +82,10 @@ export const Demo: React.FC = () => {
     () => (text ? wasm.parse_ingredient(text) : undefined),
     [text]
   );
+  const decomp = useMemo(
+    () => (text ? wasm.decompose_ingredient(text) : undefined),
+    [text]
+  );
   const parsedRich = useMemo(
     () =>
       richText ? safeParseRichText(richText, ingredientNames) : undefined,
@@ -132,6 +137,7 @@ export const Demo: React.FC = () => {
             </div>
 
             <div className="mt-5 border-t border-zinc-100 pt-5">
+              <DecompositionView decomp={decomp} />
               <IngredientResult parsed={parsed} />
             </div>
           </div>

--- a/demo-site/src/wasm.ts
+++ b/demo-site/src/wasm.ts
@@ -12,5 +12,8 @@ export const wasm = await import("./wasm/pkg/ingredient_wasm");
 export type {
   RichItem,
   WAmount as Measure,
+  WDecomposition,
+  WField,
   WScrapedRecipe as ScrapedRecipe,
+  WSegment,
 } from "./wasm/pkg/ingredient_wasm";

--- a/food-cli/Cargo.toml
+++ b/food-cli/Cargo.toml
@@ -16,6 +16,11 @@ ingredient.workspace = true
 dotenvy.workspace = true
 open = "5"
 maud = "0.27"  # compile-time, auto-escaping HTML for the corpus table
+miette.workspace = true # rich --explain diagnostics with source carets
+tabled.workspace = true # pretty CLI tables
+
+[dev-dependencies]
+rstest.workspace = true
 
 [lints]
 workspace = true

--- a/food-cli/src/explain.rs
+++ b/food-cli/src/explain.rs
@@ -1,0 +1,236 @@
+//! Diagnostic rendering for `parse-ingredient --explain`.
+//!
+//! Two modes, both rendered with miette over the *normalized* string the
+//! grammar parsed:
+//!
+//! - **Decomposition** (the common case): when the core grammar carved the line,
+//!   [`ingredient::IngredientParser::decompose`] hands us byte spans for each
+//!   amount / name / modifier; we label each one. This shows *how the grammar
+//!   split the input*.
+//! - **Digit caret** (fallback): when a recognizer or the name-only fallback
+//!   produced the result there are no grammar spans, so if a digit was present
+//!   but produced no amount we underline the digit run(s) instead.
+//!
+//! miette lives only here — the published `ingredient` crate stays miette-free.
+
+use std::ops::Range;
+
+use ingredient::{Confidence, Decomposition, Diagnostics, Field};
+use miette::{
+    GraphicalReportHandler, GraphicalTheme, LabeledSpan, MietteDiagnostic, Report, Severity,
+};
+
+/// Unicode vulgar-fraction glyphs the parser treats as part of a quantity, so
+/// `5½` is reported as one span rather than `5` with the `½` orphaned.
+const FRACTION_GLYPHS: &[char] = &[
+    '½', '⅓', '⅔', '¼', '¾', '⅕', '⅖', '⅗', '⅘', '⅙', '⅚', '⅛', '⅜', '⅝', '⅞', '⅐', '⅑', '⅒',
+];
+
+fn is_quantity_char(c: char) -> bool {
+    c.is_ascii_digit() || FRACTION_GLYPHS.contains(&c)
+}
+
+/// Byte ranges of maximal quantity runs (ASCII digits + adjacent vulgar
+/// fractions) in `input`. These are the spans we underline when the parser saw
+/// a digit but produced no amount. Pure and span-only so it can be unit-tested
+/// without rendering.
+pub fn unparsed_digit_spans(input: &str) -> Vec<Range<usize>> {
+    let mut spans = Vec::new();
+    let mut start: Option<usize> = None;
+    for (i, c) in input.char_indices() {
+        if is_quantity_char(c) {
+            start.get_or_insert(i);
+        } else if let Some(s) = start.take() {
+            spans.push(s..i);
+        }
+    }
+    if let Some(s) = start {
+        spans.push(s..input.len());
+    }
+    spans
+}
+
+fn severity_of(confidence: Confidence) -> Severity {
+    match confidence {
+        // A digit that produced no amount is a likely missed quantity — warn.
+        Confidence::Low => Severity::Warning,
+        Confidence::Medium | Confidence::High => Severity::Advice,
+    }
+}
+
+fn field_label(field: Field) -> &'static str {
+    match field {
+        Field::Amount => "amount",
+        Field::Name => "name",
+        Field::Modifier => "modifier",
+    }
+}
+
+fn message_for(diag: &Diagnostics) -> &'static str {
+    match diag.confidence {
+        Confidence::Low if diag.unparsed_digit => "quantity not parsed into an amount",
+        Confidence::Low => "low-confidence parse",
+        Confidence::Medium => "name-only parse",
+        Confidence::High => "parsed with an amount",
+    }
+}
+
+fn help_for(diag: &Diagnostics) -> String {
+    let mut parts = vec![format!("confidence: {:?}", diag.confidence)];
+    if diag.fell_back {
+        parts.push("fell back to a name-only ingredient".to_string());
+    }
+    parts.push("see the stage view below; route the fix via parser/mod.rs".to_string());
+    parts.join(" · ")
+}
+
+/// The decomposition diagnostic: one label per grammar field span.
+fn decomposition_diagnostic(decomp: &Decomposition, diag: &Diagnostics) -> MietteDiagnostic {
+    // A digit that produced no amount is informative here, not alarming: the
+    // labels already show it landed in the name/modifier, not a missed quantity.
+    let (message, severity) = if diag.unparsed_digit {
+        (
+            "no amount parsed — any digit is part of the name/modifier",
+            Severity::Warning,
+        )
+    } else {
+        ("grammar decomposition", Severity::Advice)
+    };
+
+    let labels: Vec<LabeledSpan> = decomp
+        .spans
+        .iter()
+        .map(|s| LabeledSpan::at(s.range.clone(), field_label(s.field)))
+        .collect();
+
+    MietteDiagnostic::new(message)
+        .with_severity(severity)
+        .with_labels(labels)
+        .with_help(format!(
+            "{} · grammar-stage carve (refine may move prep words — see stage view)",
+            format_args!("confidence: {:?}", diag.confidence)
+        ))
+}
+
+/// The fallback diagnostic when the grammar didn't carve the line: a digit caret
+/// when a number produced no amount, otherwise just the confidence header.
+fn fallback_diagnostic(decomp: &Decomposition, diag: &Diagnostics) -> MietteDiagnostic {
+    let mut d = MietteDiagnostic::new(message_for(diag))
+        .with_severity(severity_of(diag.confidence))
+        .with_help(help_for(diag));
+
+    if diag.unparsed_digit {
+        let labels: Vec<LabeledSpan> = unparsed_digit_spans(&decomp.source)
+            .into_iter()
+            .map(|span| LabeledSpan::at(span, "this number didn't become an amount"))
+            .collect();
+        d = d.with_labels(labels);
+    }
+    d
+}
+
+/// Render the miette report block for `--explain`. When the grammar carved the
+/// line, labels each amount/name/modifier span; otherwise falls back to a digit
+/// caret. Rendered over `decomp.source` (the normalized line the grammar saw).
+/// `use_color` mirrors the caller's `IsTerminal` gate.
+pub fn render(decomp: &Decomposition, diag: &Diagnostics, use_color: bool) -> String {
+    let d = if decomp.spans.is_empty() {
+        fallback_diagnostic(decomp, diag)
+    } else {
+        decomposition_diagnostic(decomp, diag)
+    };
+
+    let report = Report::new(d).with_source_code(decomp.source.clone());
+    let theme = if use_color {
+        GraphicalTheme::unicode()
+    } else {
+        GraphicalTheme::unicode_nocolor()
+    };
+    let handler = GraphicalReportHandler::new_themed(theme);
+    let mut out = String::new();
+    // render_report only errors if the writer fails; a String writer cannot.
+    let _ = handler.render_report(&mut out, &*report);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    // "5½" is one run: '5' at byte 3, '½' (2 bytes) at 4..6 → 3..6; "1" at 0..1.
+    #[case("1 (5½-ounce) piece", vec![0..1, 3..6])]
+    #[case("2 cups flour", vec![0..1])]
+    #[case("Juice of 1 lemon", vec![9..10])]
+    #[case("salt", vec![])]
+    // Two separate digit runs: '1' at 0, '2' at byte 7 (after "1 cup, ").
+    #[case("1 cup, 2 tbsp", vec![0..1, 7..8])]
+    fn finds_quantity_runs(#[case] input: &str, #[case] expected: Vec<Range<usize>>) {
+        assert_eq!(unparsed_digit_spans(input), expected);
+    }
+
+    fn decomp(source: &str, spans: Vec<ingredient::FieldSpan>) -> Decomposition {
+        Decomposition {
+            source: source.to_string(),
+            spans,
+        }
+    }
+
+    fn span(field: Field, range: Range<usize>, text: &str) -> ingredient::FieldSpan {
+        ingredient::FieldSpan {
+            field,
+            range,
+            text: text.to_string(),
+        }
+    }
+
+    #[test]
+    fn render_underlines_unparsed_digit_when_no_grammar_spans() {
+        // Empty spans (recognizer/fallback path) + a digit that produced no
+        // amount → the digit-caret fallback fires.
+        let diag = Diagnostics {
+            confidence: Confidence::Low,
+            fell_back: false,
+            unparsed_digit: true,
+        };
+        let out = render(&decomp("1+1 vitamins", vec![]), &diag, false);
+        assert!(out.contains("quantity not parsed into an amount"));
+        assert!(out.contains("this number didn't become an amount"));
+    }
+
+    #[test]
+    fn render_labels_grammar_decomposition() {
+        // Spans present → each field is labeled, no digit-miss caret.
+        let diag = Diagnostics {
+            confidence: Confidence::High,
+            fell_back: false,
+            unparsed_digit: false,
+        };
+        let spans = vec![
+            span(Field::Amount, 0..6, "2 cups"),
+            span(Field::Name, 7..12, "flour"),
+        ];
+        let out = render(&decomp("2 cups flour", spans), &diag, false);
+        assert!(out.contains("grammar decomposition"));
+        assert!(out.contains("amount"));
+        assert!(out.contains("name"));
+        assert!(!out.contains("this number didn't become an amount"));
+    }
+
+    #[test]
+    fn render_digit_in_name_is_informative_not_alarming() {
+        // "Pierre Ferrand 1840 Cognac": grammar carves a Name span covering the
+        // whole line; the digit is part of the name, so we say so rather than
+        // warning about a missed quantity.
+        let diag = Diagnostics {
+            confidence: Confidence::Low,
+            fell_back: false,
+            unparsed_digit: true,
+        };
+        let spans = vec![span(Field::Name, 0..26, "Pierre Ferrand 1840 Cognac")];
+        let out = render(&decomp("Pierre Ferrand 1840 Cognac", spans), &diag, false);
+        assert!(out.contains("part of the name/modifier"));
+        assert!(!out.contains("this number didn't become an amount"));
+    }
+}

--- a/food-cli/src/main.rs
+++ b/food-cli/src/main.rs
@@ -4,6 +4,9 @@
 use clap::{Parser, Subcommand};
 use recipe_epub::CookbookRecipeExt; // .parse() / .low_confidence_lines() on CookbookRecipe
 
+mod explain;
+mod tables;
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 #[command(propagate_version = true)]
@@ -501,6 +504,7 @@ async fn main() {
                 "\ntop {} parser-miss lines (corpus candidates):",
                 (*bottom).min(ranked.len())
             );
+            // Tab-separated stays grep/copy-friendly for piping into the corpus.
             for (line, n) in ranked.into_iter().take(*bottom) {
                 println!("{n}\t{line}");
             }
@@ -527,8 +531,15 @@ async fn main() {
                     eprintln!("Wrote Jaeger trace to: {output_path}");
                 }
 
-                // Compact stage report — the routing view.
+                // Compact stage report — the routing view. The miette header
+                // labels how the grammar carved the line (amount/name/modifier),
+                // or falls back to a caret on a digit that produced no amount;
+                // the stage view below shows which pipeline stage shaped the line.
                 if *explain {
+                    let (_ingredient, diag) = parser.parse_with_diagnostics(name);
+                    let decomp = parser.decompose(name);
+                    print!("{}", explain::render(&decomp, &diag, use_color));
+                    println!();
                     println!("{}", result.trace.format_stages(use_color));
                 }
 
@@ -606,9 +617,7 @@ async fn main() {
                     if *json {
                         println!("{}", serde_json::to_string_pretty(&amounts).unwrap());
                     } else {
-                        for amount in amounts {
-                            println!("{amount}");
-                        }
+                        println!("{}", tables::amount_table(&amounts));
                     }
                 }
                 Err(e) => {

--- a/food-cli/src/tables.rs
+++ b/food-cli/src/tables.rs
@@ -1,0 +1,20 @@
+//! Small `tabled` helpers for CLI output. Each returns a rendered `String` so
+//! callers keep control of `print!`/`eprintln!` and stay out of the JSON /
+//! pipeable code paths.
+
+use ingredient::unit::Measure;
+use tabled::{builder::Builder, settings::Style};
+
+/// Render parsed amounts as a value/unit/upper table.
+pub fn amount_table(amounts: &[Measure]) -> String {
+    let mut b = Builder::default();
+    b.push_record(["value", "unit", "upper"]);
+    for m in amounts {
+        let upper = m
+            .upper_value()
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        b.push_record([m.value().to_string(), m.unit().to_string(), upper]);
+    }
+    b.build().with(Style::rounded()).to_string()
+}

--- a/ingredient-parser/src/lib.rs
+++ b/ingredient-parser/src/lib.rs
@@ -228,6 +228,18 @@ pub fn from_str(input: &str) -> Ingredient {
     DEFAULT_PARSER.from_str(input)
 }
 
+/// Decompose a line into grammar-stage field spans, using the shared default
+/// parser. See [`IngredientParser::decompose`].
+///
+/// ```
+/// use ingredient::{decompose, Field};
+/// let d = decompose("2 cups flour");
+/// assert_eq!(d.spans.iter().map(|s| s.field).collect::<Vec<_>>(), vec![Field::Amount, Field::Name]);
+/// ```
+pub fn decompose(input: &str) -> Decomposition {
+    DEFAULT_PARSER.decompose(input)
+}
+
 /// Shared default parser used by the free [`from_str`]. Building an
 /// [`IngredientParser`] allocates two `HashSet<String>` of default vocab, so we
 /// construct it once and borrow it for every call. `IngredientParser` is

--- a/ingredient-parser/src/lib.rs
+++ b/ingredient-parser/src/lib.rs
@@ -259,6 +259,42 @@ pub struct Diagnostics {
     pub unparsed_digit: bool,
 }
 
+/// Which output field a source span became, for the `--explain` decomposition
+/// view (see [`decompose`](IngredientParser::decompose)).
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Field {
+    /// A measurement region (a primary, bracketed, or parenthesized amount).
+    Amount,
+    /// The ingredient name, as the grammar carved it (before refine).
+    Name,
+    /// The trailing modifier text (after the first `", "`).
+    Modifier,
+}
+
+/// A grammar-stage byte span: which slice of the normalized input the grammar
+/// assigned to a given [`Field`]. `range` indexes into [`Decomposition::source`].
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FieldSpan {
+    /// Which output field this span became.
+    pub field: Field,
+    /// Byte range into [`Decomposition::source`].
+    pub range: std::ops::Range<usize>,
+    /// The text at `range` (a copy, for convenience).
+    pub text: String,
+}
+
+/// How the grammar carved a line into fields, for the `--explain` view. See
+/// [`decompose`](IngredientParser::decompose).
+#[derive(Clone, PartialEq, Eq, Debug, Default)]
+pub struct Decomposition {
+    /// The normalized string the spans index into (what the grammar parsed).
+    pub source: String,
+    /// Grammar-stage field spans, in input order. Empty when a whole-line
+    /// recognizer or the name-only fallback produced the result (no grammar
+    /// carving to show).
+    pub spans: Vec<FieldSpan>,
+}
+
 /// Customizable ingredient parser with configurable units and adjectives
 ///
 /// This parser allows you to customize which units and adjectives are recognized

--- a/ingredient-parser/src/parser/pipeline.rs
+++ b/ingredient-parser/src/parser/pipeline.rs
@@ -218,6 +218,94 @@ impl IngredientParser {
             "parse failed"
         )
     }
+
+    /// Decompose a line into grammar-stage field spans for the `--explain`
+    /// decomposition view.
+    ///
+    /// Returns the normalized string the spans index into, plus one
+    /// [`FieldSpan`](crate::FieldSpan) per amount region / name / modifier the
+    /// grammar carved. `spans` is empty when a whole-line recognizer or the
+    /// name-only fallback produced the result (no core-grammar carving to show).
+    pub fn decompose(&self, raw: &str) -> crate::Decomposition {
+        let normalized = normalize_input(raw);
+        let (cleaned, _optional) = strip_optional_note(normalized.as_ref());
+        // Only the core grammar carves fields into spans; a whole-line
+        // recognizer produces the result without the field grammar running.
+        let spans = if self.run_recognizers(cleaned.as_ref()).is_some() {
+            Vec::new()
+        } else {
+            self.grammar_field_spans(cleaned.as_ref())
+        };
+        crate::Decomposition {
+            source: cleaned.into_owned(),
+            spans,
+        }
+    }
+
+    /// Grammar-stage field spans: re-run the [`parse_ingredient`](Self::parse_ingredient)
+    /// grammar with each value field wrapped in `consumed`, then recover each
+    /// matched slice's byte range via pointer arithmetic (the slices are always
+    /// subslices of `input`). Empty vec if the grammar doesn't parse.
+    ///
+    /// NOTE: keep the field order/shape in sync with `parse_ingredient` above.
+    fn grammar_field_spans(&self, input: &str) -> Vec<crate::FieldSpan> {
+        use crate::{Field, FieldSpan};
+        use nom::combinator::consumed;
+
+        let mp = MeasurementParser::new(&self.units, false);
+        let base = input.as_ptr() as usize;
+        // Tighten a matched slice to its non-whitespace extent and turn it into a
+        // FieldSpan; None when the slice is empty/all-whitespace.
+        let span_of = |slice: &str, field: Field| -> Option<FieldSpan> {
+            let trimmed = slice.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let start = trimmed.as_ptr() as usize - base;
+            Some(FieldSpan {
+                field,
+                range: start..start + trimmed.len(),
+                text: trimmed.to_string(),
+            })
+        };
+
+        let grammar = (
+            opt(consumed(|a| mp.parse_measurement_list(a))),
+            space0,
+            opt(consumed(|a| mp.parse_bracketed_amounts(a))),
+            space0,
+            opt(consumed(many1(parse_ingredient_text))),
+            opt(consumed(|a| mp.parse_parenthesized_amounts(a))),
+            opt(tag(", ")),
+            consumed(not_line_ending),
+        );
+
+        let Ok((_, (primary, _, bracketed, _, name, paren, _, modifier))) =
+            context("ingredient", grammar).parse(input)
+        else {
+            return Vec::new();
+        };
+
+        let mut spans = Vec::new();
+        // Each amount region is a separate `consumed` slice; collect the slices
+        // (their inner Measure values differ in shape, so keep only the &str).
+        for slice in [
+            primary.map(|(s, _)| s),
+            bracketed.map(|(s, _)| s),
+            paren.map(|(s, _)| s),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            spans.extend(span_of(slice, Field::Amount));
+        }
+        if let Some((slice, _chunks)) = name {
+            spans.extend(span_of(slice, Field::Name));
+        }
+        spans.extend(span_of(modifier.0, Field::Modifier));
+        spans.sort_by_key(|s| s.range.start);
+        spans
+    }
 }
 
 fn fallback_ingredient(input: &str) -> Ingredient {
@@ -252,4 +340,69 @@ fn merge_amounts(
         .flatten()
         .flatten()
         .collect()
+}
+
+#[cfg(test)]
+mod decompose_tests {
+    use crate::{Field, IngredientParser};
+    use rstest::rstest;
+
+    /// (field, text) pairs expected from `decompose`, in span order.
+    type Expected = &'static [(Field, &'static str)];
+
+    #[rstest]
+    #[case("2 cups flour", &[(Field::Amount, "2 cups"), (Field::Name, "flour")])]
+    #[case(
+        "1 cup / 240ml water",
+        &[(Field::Amount, "1 cup / 240ml"), (Field::Name, "water")]
+    )]
+    #[case(
+        "2¼ cups all-purpose flour, sifted",
+        &[
+            (Field::Amount, "2¼ cups"),
+            (Field::Name, "all-purpose flour"),
+            (Field::Modifier, "sifted"),
+        ]
+    )]
+    // Grammar-stage carve: prep adjectives stay in the name span here; refine
+    // moves them later (the --explain stage view shows that separately).
+    #[case(
+        "2 chopped fresh basil",
+        &[(Field::Amount, "2"), (Field::Name, "chopped fresh basil")]
+    )]
+    #[case("salt", &[(Field::Name, "salt")])]
+    fn decompose_carves_fields(#[case] input: &str, #[case] expected: Expected) {
+        let parser = IngredientParser::new();
+        let decomp = parser.decompose(input);
+
+        let got: Vec<(Field, &str)> = decomp
+            .spans
+            .iter()
+            .map(|s| (s.field, s.text.as_str()))
+            .collect();
+        let want: Vec<(Field, &str)> = expected.to_vec();
+        assert_eq!(got, want, "decompose({input:?})");
+
+        // Every span must index back into `source` and match its `text`, and
+        // spans must not overlap.
+        let mut prev_end = 0;
+        for s in &decomp.spans {
+            assert_eq!(&decomp.source[s.range.clone()], s.text, "span text/range");
+            assert!(s.range.start >= prev_end, "spans overlap in {input:?}");
+            prev_end = s.range.end;
+        }
+    }
+
+    #[test]
+    fn recognizer_handled_line_has_no_grammar_spans() {
+        // "Juice of 1 lemon" is produced by the x_of_construction recognizer,
+        // not the field grammar — so there are no grammar-stage spans to show.
+        let parser = IngredientParser::new();
+        let decomp = parser.decompose("Juice of 1 lemon");
+        assert!(
+            decomp.spans.is_empty(),
+            "recognizer result should yield no spans, got {:?}",
+            decomp.spans
+        );
+    }
 }

--- a/ingredient-wasm/src/lib.rs
+++ b/ingredient-wasm/src/lib.rs
@@ -1,12 +1,13 @@
 use std::{collections::HashSet, str::FromStr};
 
 use ingredient::{
-    from_str as parse_ingredient_str,
+    decompose as decompose_str, from_str as parse_ingredient_str,
     ingredient::Ingredient,
     rich_text::{Chunk, RichParser},
     unit::{convert_measure_with_graph, is_valid, make_graph, print_graph, Measure, MeasureKind},
     unit_mapping::{parse_unit_mapping as parse_unit_mapping_internal, ParsedUnitMapping},
     util::truncate_3_decimals,
+    Decomposition, Field,
 };
 use recipe_scraper::{RecipeSection, RecipeTimes, ScrapedRecipe};
 use serde::{Deserialize, Serialize};
@@ -250,6 +251,80 @@ impl From<Chunk> for RichItem {
 #[serde(transparent)]
 pub struct RichItems(pub Vec<RichItem>);
 
+/// Which output field a decomposition segment became (mirrors `Field`). Renders
+/// as the TS string union `"amount" | "name" | "modifier"`.
+#[derive(Tsify, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WField {
+    Amount,
+    Name,
+    Modifier,
+}
+
+impl From<Field> for WField {
+    fn from(f: Field) -> Self {
+        match f {
+            Field::Amount => WField::Amount,
+            Field::Name => WField::Name,
+            Field::Modifier => WField::Modifier,
+        }
+    }
+}
+
+/// One contiguous chunk of the decomposed line: either a labeled field span or
+/// unlabeled gap text. The segments concatenate back to the whole source, so JS
+/// renders them in order with no byte-offset math (the Rust spans are UTF-8 byte
+/// ranges, which don't map to JS UTF-16 indices). Into-only.
+#[derive(Tsify, Serialize)]
+pub struct WSegment {
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<WField>,
+}
+
+/// How the grammar carved a line into fields (mirrors `Decomposition`), as an
+/// ordered list of segments covering the whole source. `segments` carries no
+/// labeled entries when a recognizer or name-only fallback produced the result.
+/// Into-only.
+#[derive(Tsify, Serialize)]
+#[tsify(into_wasm_abi)]
+pub struct WDecomposition {
+    pub source: String,
+    pub segments: Vec<WSegment>,
+}
+
+impl From<Decomposition> for WDecomposition {
+    fn from(d: Decomposition) -> Self {
+        // Walk the sorted, non-overlapping spans, emitting any gap text before
+        // each labeled span, then the span itself, then the trailing gap.
+        let mut segments = Vec::new();
+        let mut prev_end = 0usize;
+        for span in &d.spans {
+            if span.range.start > prev_end {
+                segments.push(WSegment {
+                    text: d.source[prev_end..span.range.start].to_string(),
+                    field: None,
+                });
+            }
+            segments.push(WSegment {
+                text: span.text.clone(),
+                field: Some(span.field.into()),
+            });
+            prev_end = span.range.end;
+        }
+        if prev_end < d.source.len() {
+            segments.push(WSegment {
+                text: d.source[prev_end..].to_string(),
+                field: None,
+            });
+        }
+        WDecomposition {
+            source: d.source,
+            segments,
+        }
+    }
+}
+
 // Hand-authored boundary types that can't be derived: `AmountKind` (a
 // template-literal union) and the nutrient-conversion result record.
 #[wasm_bindgen]
@@ -282,6 +357,14 @@ fn to_js<T: Serialize>(v: &T, ctx: &str) -> Result<JsValue, String> {
 #[wasm_bindgen]
 pub fn parse_ingredient(input: &str) -> WIngredient {
     parse_ingredient_str(input).into()
+}
+
+/// Decompose a line into ordered `{text, field?}` segments showing how the
+/// grammar carved it into amount / name / modifier spans (for the demo's
+/// diagnostic-style annotation).
+#[wasm_bindgen]
+pub fn decompose_ingredient(input: &str) -> WDecomposition {
+    decompose_str(input).into()
 }
 
 #[wasm_bindgen]
@@ -437,5 +520,45 @@ mod tests {
         ] {
             assert_eq!(kind_str(unit), want, "unit: {unit}");
         }
+    }
+
+    /// The decomposition segments must concatenate back to the source exactly
+    /// (no dropped/duplicated text) and carry the right field labels — this is
+    /// what lets the JS side render without any byte-offset math.
+    #[test]
+    fn decomposition_segments_cover_source() {
+        let w: WDecomposition = decompose_str("2¼ cups all-purpose flour, sifted").into();
+        let joined: String = w.segments.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(joined, w.source, "segments must reconstruct the source");
+
+        // Labeled segments, in order, are the grammar fields.
+        let labeled: Vec<(&str, &str)> = w
+            .segments
+            .iter()
+            .filter_map(|s| match &s.field {
+                Some(WField::Amount) => Some(("amount", s.text.as_str())),
+                Some(WField::Name) => Some(("name", s.text.as_str())),
+                Some(WField::Modifier) => Some(("modifier", s.text.as_str())),
+                None => None,
+            })
+            .collect();
+        assert_eq!(
+            labeled,
+            vec![
+                ("amount", "2¼ cups"),
+                ("name", "all-purpose flour"),
+                ("modifier", "sifted"),
+            ]
+        );
+    }
+
+    /// A recognizer-handled line has no grammar carve → all segments unlabeled,
+    /// still reconstructing the source.
+    #[test]
+    fn recognizer_line_has_no_labeled_segments() {
+        let w: WDecomposition = decompose_str("Juice of 1 lemon").into();
+        let joined: String = w.segments.iter().map(|s| s.text.as_str()).collect();
+        assert_eq!(joined, w.source);
+        assert!(w.segments.iter().all(|s| s.field.is_none()));
     }
 }


### PR DESCRIPTION
Adds a **decomposition view** that shows how the grammar carves an ingredient line into `amount` / `name` / `modifier` spans, surfaced in three places. This branch is stacked, so it contains three commits forming one feature arc:

### `09c8797` — parser: `decompose()` grammar-stage field spans
New additive, non-breaking API: `Field`, `FieldSpan`, `Decomposition`, and `IngredientParser::decompose()`. It re-runs the `parse_ingredient` grammar with each field wrapped in nom's `consumed`, recovering byte ranges via pointer arithmetic **over the normalized string**.

Capturing spans at the **grammar stage** (before refine) and indexing into the normalized string sidesteps two blockers: `normalize`'s `Cow::Owned` rewrites break offset-mapping back to the raw input, and `refine` transforms the final name so it's often not a verbatim substring. `spans` is empty when a whole-line recognizer or the name-only fallback produced the result.

### `dc58504` — cli: miette `--explain` decomposition + tabled parse-amount
`parse-ingredient --explain` renders a miette report labeling each amount/name/modifier span over the normalized line; when a recognizer/fallback produced the result it falls back to underlining a digit that produced no amount. Fixes a prior false positive: `Pierre Ferrand 1840 Cognac` now shows the line as `name` (the digit is part of the name) instead of warning about a missed quantity. `parse-amount` (non-JSON) prints a value/unit/upper table. JSON / pipeable paths and `--debug` are untouched; miette/tabled live only in food-cli.

### `2176b16` — demo: decomposition view via `decompose_ingredient` wasm export
The demo site shows the carve live as you type: the source in monospace with a colored underline under each field + a legend (amount=blue, name=emerald, modifier=amber).

- core: free `ingredient::decompose()` (parallels `from_str`).
- wasm: new `decompose_ingredient` returning `WDecomposition`. **Segmentation runs in Rust** (`From<Decomposition>`) — it emits ordered `{text, field?}` chunks covering the whole source — so JS renders them in order with **no byte-offset math**, avoiding the UTF-8-byte-range (Rust) vs UTF-16-index (JS) mismatch (e.g. the `¼` in `2¼`).
- demo: new `DecompositionView` component, additive above the existing parsed result.

## Reviewer notes
- **Stacked PR**: the first two commits were already on local `main` but not on `origin/main`, so they appear here. The demo work genuinely depends on the parser API from `09c8797`.
- `demo-site/src/wasm/pkg/` is gitignored; CI (`make build-demo-site` + wasm-pack) regenerates it on the demo-site and deploy jobs.

## Verification
- `cargo nextest run --workspace` green (new `decompose` rstest + wasm segmentation host tests); clippy `-D warnings` + fmt clean.
- demo: `pnpm build` (tsc) + `pnpm lint` clean; browser-verified the flour line (3 underlines + legend), `Pierre Ferrand 1840 Cognac` (whole line = name), and `Juice of 1 lemon` (recognizer caption); console error-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)