### PR TITLE
chore(ci): quiet Renovate — unblock automerge + batch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,11 @@
   "extends": [
     "config:recommended"
   ],
+  "schedule": [
+    "before 9am on monday"
+  ],
+  "prConcurrentLimit": 4,
+  "prHourlyLimit": 2,
   "packageRules": [
     {
       "groupName": "egui",
@@ -15,6 +20,18 @@
       "groupName": "reqwest",
       "matchPackageNames": [
         "reqwest{/,}**"
+      ]
+    },
+    {
+      "groupName": "github-actions",
+      "matchManagers": [
+        "github-actions"
+      ]
+    },
+    {
+      "groupName": "demo-site js deps",
+      "matchManagers": [
+        "npm"
       ]
     },
     {

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -14,6 +14,10 @@ concurrency:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Skip bot-authored PRs (Renovate, Dependabot): the action refuses to review
+    # non-human actors and would otherwise post a failing "review" check that
+    # blocks Renovate's automerge — and reviewing dependency bumps wastes budget.
+    if: ${{ github.actor != 'renovate[bot]' && github.actor != 'dependabot[bot]' }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Why

Renovate's config already enables automerge for minor/pin updates, but they never auto-merged — they piled up needing manual merges (six were open today). Root cause: the **Claude PR Review** check fails on every bot-authored PR (`Workflow initiated by non-human actor: renovate`), and Renovate waits for all checks to be green before automerging.

## Changes

**`.github/workflows/claude-review.yml`** — skip the review job for `renovate[bot]` / `dependabot[bot]`. The action refuses to review non-human actors anyway, and reviewing dependency bumps wastes review budget. With the spurious red check gone, minor/pin updates flow through their real build+test checks and auto-merge unattended.

**`.github/renovate.json`** — reduce PR volume:
- Group **GitHub Actions** updates into one PR (`github-actions`)
- Group **demo-site JS deps** (npm) into one PR
- `prConcurrentLimit: 4`, `prHourlyLimit: 2`
- `schedule: before 9am on monday` — batch updates weekly

Unchanged: major bumps still open a PR without automerge (kept for human review); patch/digest stay disabled; egui & reqwest groups preserved.

## Tradeoff

With the weekly `schedule`, automerge of a green PR also runs on the weekly cycle, so a passing PR may stay open up to ~a week before merging. If you'd rather merges be instant, drop the `schedule` (keep the grouping + limits), or we can wire GitHub-native auto-merge instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nickysemenza/ingredient-parser/pull/336" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->