### PR TITLE
Unify parser stage pipelines and DRY shared helpers

### DIFF
--- a/ingredient-parser/readme.md
+++ b/ingredient-parser/readme.md
@@ -15,6 +15,41 @@
 
 ---
 
+## Parsing pipeline
+
+Each ingredient line flows through four stages. Ordered tables in the codebase (`REWRITES`, `RECOGNIZERS`, `REFINE_PIPELINE`) are the single source of truth for each stage — add a row to extend.
+
+```mermaid
+flowchart TD
+    input["Raw ingredient line"]
+    normalize["normalize · REWRITES"]
+    optNote["strip optional note"]
+    tryRec["recognize · RECOGNIZERS"]
+    tryCore["grammar · nom parse"]
+    refine["refine · REFINE_PIPELINE"]
+    fallback["name-only fallback"]
+    classify["classify usage"]
+    output["Ingredient"]
+
+    input --> normalize --> optNote --> tryRec
+    tryRec -->|match| classify
+    tryRec -->|no match| tryCore
+    tryCore --> refine --> classify
+    tryCore -->|fail| fallback --> classify
+    classify --> output
+```
+
+| Stage | What it does | Example fix |
+|-------|--------------|-------------|
+| **normalize** | Pre-parse string rewrites | Strip footnote markers, lift dimensional asides |
+| **recognize** | Whole-line special forms (first match wins) | `"Juice of 1 lemon"`, `"Flour — 2 cups"` |
+| **grammar** | Nom combinators capture amounts, name, modifier | New unit token in measurement grammar |
+| **refine** | Post-parse passes recover misplaced text | Move `"chopped"` from name into modifier |
+
+To see which stage shaped a line: `cargo run -p food-cli --quiet -- parse-ingredient --explain "<line>"`
+
+---
+
 ## Example
 
 Given the input:

--- a/ingredient-parser/src/ingredient.rs
+++ b/ingredient-parser/src/ingredient.rs
@@ -148,6 +148,24 @@ impl Ingredient {
         }
     }
 
+    /// Parser-internal ingredient without [`classify_usage`]. The grammar and
+    /// recognizer paths build this shape; usage is set when lowering from IR.
+    pub(crate) fn from_parser_parts(
+        name: impl Into<String>,
+        amounts: Vec<Measure>,
+        modifier: Option<String>,
+        optional: bool,
+    ) -> Self {
+        Ingredient {
+            name: name.into(),
+            amounts,
+            modifier,
+            optional,
+            usage: Default::default(),
+            parse_notes: Default::default(),
+        }
+    }
+
     /// Create a new optional ingredient with the given components
     ///
     /// # Example

--- a/ingredient-parser/src/parser/helpers.rs
+++ b/ingredient-parser/src/parser/helpers.rs
@@ -18,6 +18,14 @@ use crate::unit::Measure;
 
 pub(crate) type Res<T, U> = IResult<T, U, VerboseError<T>>;
 
+/// Lowercase `s` only when the result preserves byte length, so offsets found in
+/// the lowercase copy align with `s` for slicing. Returns `None` when case-folding
+/// changes byte length (e.g. `'İ'` → `"i\u{307}"`).
+pub(crate) fn byte_aligned_lowercase(s: &str) -> Option<String> {
+    let lower = s.to_lowercase();
+    (lower.len() == s.len()).then_some(lower)
+}
+
 /// Parse a simple amount string like "4 lb", "$5", "120g", "1/2 cup"
 ///
 /// Crate-internal utility for parsing standalone amount strings without full
@@ -137,6 +145,19 @@ fn number_word<'a>(word: &'static str, value: f64, input: &'a str) -> Res<&'a st
     }
 }
 
+/// Try each spelled-out number word from [`vocab::NUMBER_WORDS`], longest first.
+fn try_spelled_number_words(input: &str) -> Res<&str, f64> {
+    for &(word, value) in crate::parser::vocab::NUMBER_WORDS {
+        if let Ok(result) = number_word(word, value, input) {
+            return Ok(result);
+        }
+    }
+    Err(nom::Err::Error(VerboseError::from_error_kind(
+        input,
+        nom::error::ErrorKind::Tag,
+    )))
+}
+
 /// Parse spelled-out text numbers: integer words ("one".."twelve", "dozen") and
 /// the articles "a"/"an" (which mean a quantity of one). Numeric words require a
 /// word boundary so they never match inside a larger word.
@@ -144,20 +165,7 @@ pub(crate) fn text_number(input: &str) -> Res<&str, f64> {
     context(
         "text_number",
         alt((
-            |i| number_word("twelve", 12.0, i),
-            |i| number_word("eleven", 11.0, i),
-            |i| number_word("ten", 10.0, i),
-            |i| number_word("nine", 9.0, i),
-            |i| number_word("eight", 8.0, i),
-            |i| number_word("seven", 7.0, i),
-            |i| number_word("six", 6.0, i),
-            |i| number_word("five", 5.0, i),
-            |i| number_word("four", 4.0, i),
-            |i| number_word("three", 3.0, i),
-            |i| number_word("two", 2.0, i),
-            |i| number_word("one", 1.0, i),
-            |i| number_word("dozen", 12.0, i),
-            |i| number_word("half", 0.5, i),
+            try_spelled_number_words,
             |i| tag_no_case("an ").parse(i).map(|(r, _)| (r, 1.0)),
             |i| tag_no_case("a ").parse(i).map(|(r, _)| (r, 1.0)),
         )),

--- a/ingredient-parser/src/parser/mod.rs
+++ b/ingredient-parser/src/parser/mod.rs
@@ -35,7 +35,8 @@
 //!   rewrite in [`normalize`].
 //!
 //! The `normalize::REWRITES`, `recognize::RECOGNIZERS`, and `refine::REFINE_PIPELINE`
-//! lists are each an ordered, named, one-line-to-extend source of truth; the
+//! tables (built via [`stage::define_stage_pipeline!`](crate::define_stage_pipeline))
+//! are each an ordered, named, one-line-to-extend source of truth; the
 //! refine order is load-bearing (see [`refine`]). Always add a corpus row for
 //! the fix (`tests/corpus/corpus.jsonl`).
 
@@ -46,11 +47,13 @@ pub(crate) mod normalize;
 pub(crate) mod pipeline;
 pub(crate) mod recognize;
 pub(crate) mod refine;
+pub(crate) mod stage;
 pub(crate) mod vocab;
 
 pub(crate) use helpers::parse_amount_string;
 pub(crate) use helpers::{
-    Res, parse_ingredient_text, parse_unit_text, text_number, thousands_number,
+    Res, byte_aligned_lowercase, parse_ingredient_text, parse_unit_text, text_number,
+    thousands_number,
 };
 pub(crate) use measurement::guards::is_distance_unit;
 pub(crate) use measurement::{MeasurementMode, MeasurementParser};

--- a/ingredient-parser/src/parser/normalize.rs
+++ b/ingredient-parser/src/parser/normalize.rs
@@ -51,12 +51,7 @@ fn strip_footnote_markers(input: &str) -> Cow<'_, str> {
 /// note)"). Anchored to the end so a mid-name asterisk is untouched; the Unicode
 /// circled-digit markers are handled by `strip_footnote_markers`.
 fn strip_trailing_footnote_markers(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static TRAILING_MARK: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"\s*[*\u{2020}\u{2021}]+\s*$").expect("invalid trailing-footnote regex")
-    });
+    crate::lazy_regex!(TRAILING_MARK, r"\s*[*\u{2020}\u{2021}]+\s*$");
     TRAILING_MARK.replace(input, "")
 }
 
@@ -66,13 +61,10 @@ fn strip_trailing_footnote_markers(input: &str) -> Cow<'_, str> {
 /// it lands at the head of the name ("– shiitake mushrooms"). The trailing
 /// whitespace requirement keeps a hyphenated/negative leading token untouched.
 fn strip_leading_bullet(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static LEADING_BULLET: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"^\s*[-\u{2013}\u{2014}\u{2022}\u{00B7}\u{2219}*]\s+")
-            .expect("invalid leading-bullet regex")
-    });
+    crate::lazy_regex!(
+        LEADING_BULLET,
+        r"^\s*[-\u{2013}\u{2014}\u{2022}\u{00B7}\u{2219}*]\s+"
+    );
     LEADING_BULLET.replace(input, "")
 }
 
@@ -89,15 +81,10 @@ fn strip_leading_bullet(input: &str) -> Cow<'_, str> {
 /// page ref with real content ("(from Lamb Meat Soup, this page)") is left for
 /// the modifier — only pure navigation cruft is dropped.
 fn strip_cross_reference(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static CROSS_REF: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(
-            r"(?i)\s*\(\s*(?:see\s+)?(?:this page|page\s+\d+)(?:[\s,;]*(?:to|or|and)?[\s,;]*(?:see\s+)?(?:this page|page\s+\d+))*\s*\)",
-        )
-        .expect("invalid cross-reference regex")
-    });
+    crate::lazy_regex!(
+        CROSS_REF,
+        r"(?i)\s*\(\s*(?:see\s+)?(?:this page|page\s+\d+)(?:[\s,;]*(?:to|or|and)?[\s,;]*(?:see\s+)?(?:this page|page\s+\d+))*\s*\)"
+    );
     CROSS_REF.replace_all(input, "")
 }
 
@@ -107,12 +94,7 @@ fn strip_cross_reference(input: &str) -> Cow<'_, str> {
 /// exactly an optional "see" plus "note"/"notes", so a paren carrying real
 /// content ("(note the color)") is left for the modifier.
 fn strip_note_reference(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static NOTE_REF: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"(?i)\s*\(\s*(?:see\s+)?notes?\s*\)").expect("invalid note-reference regex")
-    });
+    crate::lazy_regex!(NOTE_REF, r"(?i)\s*\(\s*(?:see\s+)?notes?\s*\)");
     NOTE_REF.replace_all(input, "")
 }
 
@@ -122,15 +104,10 @@ fn strip_note_reference(input: &str) -> Cow<'_, str> {
 /// Meringue", `{recipe:1}`). Anchored to a leading quantity so prose uses of
 /// "batch" elsewhere in a line are untouched; the quantity is preserved.
 fn rewrite_batch_of_to_recipe(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static BATCH_OF: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(
-            r"(?i)^(\s*[\d\x{00BC}-\x{00BE}\x{2150}-\x{215E}][\d\x{00BC}-\x{00BE}\x{2150}-\x{215E}\s./-]*\s+)batch(?:es)?\s+of\s+",
-        )
-        .expect("invalid batch-of regex")
-    });
+    crate::lazy_regex!(
+        BATCH_OF,
+        r"(?i)^(\s*[\d\x{00BC}-\x{00BE}\x{2150}-\x{215E}][\d\x{00BC}-\x{00BE}\x{2150}-\x{215E}\s./-]*\s+)batch(?:es)?\s+of\s+"
+    );
     BATCH_OF.replace(input, "${1}recipe ")
 }
 
@@ -142,15 +119,10 @@ fn rewrite_batch_of_to_recipe(input: &str) -> Cow<'_, str> {
 /// the modifier. Running before `strip_cross_reference`, this peels off the ref
 /// and leaves the bare "(optional)" for `strip_optional_note` to flag.
 fn split_crossref_optional(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static CROSS_REF_OPTIONAL: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(
-            r"(?i)\(\s*(?:see\s+)?(?:this page|page\s+\d+)(?:[\s,;]*(?:to|or|and)?[\s,;]*(?:see\s+)?(?:this page|page\s+\d+))*[\s,;]+optional\s*\)",
-        )
-        .expect("invalid cross-reference+optional regex")
-    });
+    crate::lazy_regex!(
+        CROSS_REF_OPTIONAL,
+        r"(?i)\(\s*(?:see\s+)?(?:this page|page\s+\d+)(?:[\s,;]*(?:to|or|and)?[\s,;]*(?:see\s+)?(?:this page|page\s+\d+))*[\s,;]+optional\s*\)"
+    );
     CROSS_REF_OPTIONAL.replace_all(input, "(optional)")
 }
 
@@ -159,11 +131,9 @@ fn split_crossref_optional(input: &str) -> Cow<'_, str> {
 /// immediately followed by a number so ordinary names ("the works seasoning")
 /// are untouched. ("a"/"an" already read as a quantity of 1, so they're left.)
 fn strip_leading_determiner(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static LEADING_THE: LazyLock<Regex> = LazyLock::new(|| {
+    crate::lazy_regex!(LEADING_THE, {
+        use regex::Regex;
         let frac = crate::fraction::VULGAR_FRACTIONS;
-        #[allow(clippy::expect_used)]
         Regex::new(&format!(r"(?i)^the\s+([0-9{frac}])")).expect("invalid leading-the regex")
     });
     LEADING_THE.replace(input, "$1")
@@ -179,12 +149,7 @@ fn strip_leading_determiner(input: &str) -> Cow<'_, str> {
 /// quantity, it's kept — dropping it would silently zero the amount, whereas
 /// leaving the digit lets the parse surface `unparsed_digit` for review instead.
 fn strip_minus_equivalence(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static MINUS_PAREN: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"\s*\([^)]*\bminus\b[^)]*\)").expect("invalid minus-equivalence regex")
-    });
+    crate::lazy_regex!(MINUS_PAREN, r"\s*\([^)]*\bminus\b[^)]*\)");
     let stripped = MINUS_PAREN.replace_all(input, "");
     // `replace_all` borrows unchanged when nothing matched.
     if matches!(stripped, Cow::Borrowed(_)) {
@@ -208,11 +173,9 @@ fn strip_minus_equivalence(input: &str) -> Cow<'_, str> {
 /// secondary amount. Scoped to a parenthetical whose content starts with a number
 /// so ordinary "(total recipe)"-style asides are untouched.
 fn strip_total_in_measure_paren(input: &str) -> Cow<'_, str> {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static TOTAL_PAREN: LazyLock<Regex> = LazyLock::new(|| {
+    crate::lazy_regex!(TOTAL_PAREN, {
+        use regex::Regex;
         let frac = crate::fraction::VULGAR_FRACTIONS;
-        #[allow(clippy::expect_used)]
         Regex::new(&format!(r"(?i)\(([0-9{frac}][^)]*?)\s+(?:in\s+)?total\)"))
             .expect("invalid total-paren regex")
     });
@@ -313,12 +276,8 @@ fn is_bare_dimension(tok: &str) -> bool {
 /// A leading count: digits/decimal/fraction ("1", "1½", "2.5") or a spelled-out
 /// small number ("one" … "twelve", "a"/"an").
 fn is_count_token(tok: &str) -> bool {
-    const SPELLED: &[&str] = &[
-        "a", "an", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
-        "eleven", "twelve",
-    ];
     let lower = tok.to_lowercase();
-    SPELLED.contains(&lower.as_str())
+    crate::parser::vocab::SPELLED_COUNTS.contains(&lower.as_str())
         || (!tok.is_empty()
             && tok.chars().all(|c| {
                 c.is_ascii_digit() || c == '.' || c == '/' || crate::fraction::is_vulgar(c)
@@ -346,149 +305,44 @@ fn is_dimension_descriptor(tok: &str) -> bool {
 /// (`Cow::Owned`) or unchanged (`Cow::Borrowed`).
 type Rewrite = fn(&str) -> Cow<'_, str>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum RewriteId {
-    StripNbsp,
-    StripLeadingBullet,
-    StripFootnoteMarkers,
-    StripTrailingFootnoteMarkers,
-    SplitCrossrefOptional,
-    StripCrossReference,
-    StripNoteReference,
-    RewriteBatchOfToRecipe,
-    StripLeadingDeterminer,
-    StripMinusEquivalence,
-    StripTotalInMeasureParen,
-    LiftLeadingDimension,
-    LiftLeadingPieceDimension,
+crate::define_stage_pipeline! {
+    enum RewriteId,
+    struct RewriteEntry,
+    const REWRITES: &[RewriteEntry],
+    type Rewrite = Rewrite,
+    trace: none,
+    (StripNbsp, "strip_nbsp", strip_nbsp),
+    (StripLeadingBullet, "strip_leading_bullet", strip_leading_bullet),
+    (StripFootnoteMarkers, "strip_footnote_markers", strip_footnote_markers),
+    (
+        StripTrailingFootnoteMarkers,
+        "strip_trailing_footnote_markers",
+        strip_trailing_footnote_markers
+    ),
+    (SplitCrossrefOptional, "split_crossref_optional", split_crossref_optional),
+    (StripCrossReference, "strip_cross_reference", strip_cross_reference),
+    (StripNoteReference, "strip_note_reference", strip_note_reference),
+    (RewriteBatchOfToRecipe, "rewrite_batch_of_to_recipe", rewrite_batch_of_to_recipe),
+    (StripLeadingDeterminer, "strip_leading_determiner", strip_leading_determiner),
+    (StripMinusEquivalence, "strip_minus_equivalence", strip_minus_equivalence),
+    (StripTotalInMeasureParen, "strip_total_in_measure_paren", strip_total_in_measure_paren),
+    (LiftLeadingDimension, "lift_leading_dimension", lift_leading_dimension),
+    (
+        LiftLeadingPieceDimension,
+        "lift_leading_piece_dimension",
+        lift_leading_piece_dimension
+    ),
 }
-
-impl RewriteId {
-    const fn as_str(self) -> &'static str {
-        match self {
-            RewriteId::StripNbsp => "strip_nbsp",
-            RewriteId::StripLeadingBullet => "strip_leading_bullet",
-            RewriteId::StripFootnoteMarkers => "strip_footnote_markers",
-            RewriteId::StripTrailingFootnoteMarkers => "strip_trailing_footnote_markers",
-            RewriteId::SplitCrossrefOptional => "split_crossref_optional",
-            RewriteId::StripCrossReference => "strip_cross_reference",
-            RewriteId::StripNoteReference => "strip_note_reference",
-            RewriteId::RewriteBatchOfToRecipe => "rewrite_batch_of_to_recipe",
-            RewriteId::StripLeadingDeterminer => "strip_leading_determiner",
-            RewriteId::StripMinusEquivalence => "strip_minus_equivalence",
-            RewriteId::StripTotalInMeasureParen => "strip_total_in_measure_paren",
-            RewriteId::LiftLeadingDimension => "lift_leading_dimension",
-            RewriteId::LiftLeadingPieceDimension => "lift_leading_piece_dimension",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum RewritePhase {
-    Artifact,
-    Reference,
-    RecipeAlias,
-    GrammarLift,
-}
-
-#[derive(Clone, Copy)]
-struct RewriteEntry {
-    id: RewriteId,
-    phase: RewritePhase,
-    run: Rewrite,
-}
-
-impl RewriteEntry {
-    const fn new(id: RewriteId, phase: RewritePhase, run: Rewrite) -> Self {
-        Self { id, phase, run }
-    }
-}
-
-/// The ordered pre-parse rewrite pipeline. Each entry runs on the output of the
-/// previous one; a borrow result means "no change" and is threaded through
-/// without allocating. Each entry's ID owns the trace label used in the
-/// parse trace (mirrors `refine::REFINE_PIPELINE`). Adding a rewrite is a one-line
-/// edit here.
-const REWRITES: &[RewriteEntry] = &[
-    RewriteEntry::new(RewriteId::StripNbsp, RewritePhase::Artifact, strip_nbsp),
-    RewriteEntry::new(
-        RewriteId::StripLeadingBullet,
-        RewritePhase::Artifact,
-        strip_leading_bullet,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripFootnoteMarkers,
-        RewritePhase::Artifact,
-        strip_footnote_markers,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripTrailingFootnoteMarkers,
-        RewritePhase::Artifact,
-        strip_trailing_footnote_markers,
-    ),
-    RewriteEntry::new(
-        RewriteId::SplitCrossrefOptional,
-        RewritePhase::Reference,
-        split_crossref_optional,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripCrossReference,
-        RewritePhase::Reference,
-        strip_cross_reference,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripNoteReference,
-        RewritePhase::Reference,
-        strip_note_reference,
-    ),
-    RewriteEntry::new(
-        RewriteId::RewriteBatchOfToRecipe,
-        RewritePhase::RecipeAlias,
-        rewrite_batch_of_to_recipe,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripLeadingDeterminer,
-        RewritePhase::Artifact,
-        strip_leading_determiner,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripMinusEquivalence,
-        RewritePhase::Reference,
-        strip_minus_equivalence,
-    ),
-    RewriteEntry::new(
-        RewriteId::StripTotalInMeasureParen,
-        RewritePhase::Reference,
-        strip_total_in_measure_paren,
-    ),
-    RewriteEntry::new(
-        RewriteId::LiftLeadingDimension,
-        RewritePhase::GrammarLift,
-        lift_leading_dimension,
-    ),
-    RewriteEntry::new(
-        RewriteId::LiftLeadingPieceDimension,
-        RewritePhase::GrammarLift,
-        lift_leading_piece_dimension,
-    ),
-];
 
 /// Apply one rewrite to the accumulator, preserving its owned-ness: a borrowed
 /// result means the rewrite changed nothing, so the accumulator is kept as-is
 /// (no allocation on the common path). When tracing, a rewrite that *did* change
 /// the line emits a before→after node so `--explain` shows which rewrite fired.
 fn apply_rewrite<'a>(acc: Cow<'a, str>, rewrite: &RewriteEntry) -> Cow<'a, str> {
-    let RewriteEntry {
-        id,
-        phase: _phase,
-        run,
-    } = *rewrite;
+    let RewriteEntry { run, .. } = *rewrite;
     match run(acc.as_ref()) {
         Cow::Owned(rewritten) => {
-            if crate::trace::is_tracing_enabled() {
-                crate::trace::trace_enter(id.as_str(), acc.as_ref());
-                crate::trace::trace_exit_success(0, &rewritten);
-            }
+            crate::trace::trace_on_change(rewrite.id().as_str(), acc.as_ref(), &rewritten, true);
             Cow::Owned(rewritten)
         }
         Cow::Borrowed(_) => acc,
@@ -528,16 +382,8 @@ pub(super) fn normalize_input(input: &str) -> Cow<'_, str> {
 /// whole-line "(optional)" (nothing else) is left for the optional-ingredient
 /// path and not treated as a note.
 pub(super) fn strip_optional_note(input: &str) -> (Cow<'_, str>, bool) {
-    use regex::Regex;
-    use std::sync::LazyLock;
-    static PAREN: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"(?i)\s*\(optional\)").expect("invalid optional-note regex")
-    });
-    static TRAIL_WORD: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"(?i),?\s+optional\s*$").expect("invalid optional-word regex")
-    });
+    crate::lazy_regex!(PAREN, r"(?i)\s*\(optional\)");
+    crate::lazy_regex!(TRAIL_WORD, r"(?i),?\s+optional\s*$");
 
     let trimmed = input.trim();
     // Whole-line "(optional)" → leave for try_parse_optional_ingredient.
@@ -655,333 +501,4 @@ pub(super) fn collapse_whitespace(input: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-    use std::collections::HashSet;
-
-    const EXPECTED_REWRITES: &[(RewriteId, RewritePhase)] = &[
-        (RewriteId::StripNbsp, RewritePhase::Artifact),
-        (RewriteId::StripLeadingBullet, RewritePhase::Artifact),
-        (RewriteId::StripFootnoteMarkers, RewritePhase::Artifact),
-        (
-            RewriteId::StripTrailingFootnoteMarkers,
-            RewritePhase::Artifact,
-        ),
-        (RewriteId::SplitCrossrefOptional, RewritePhase::Reference),
-        (RewriteId::StripCrossReference, RewritePhase::Reference),
-        (RewriteId::StripNoteReference, RewritePhase::Reference),
-        (RewriteId::RewriteBatchOfToRecipe, RewritePhase::RecipeAlias),
-        (RewriteId::StripLeadingDeterminer, RewritePhase::Artifact),
-        (RewriteId::StripMinusEquivalence, RewritePhase::Reference),
-        (RewriteId::StripTotalInMeasureParen, RewritePhase::Reference),
-        (RewriteId::LiftLeadingDimension, RewritePhase::GrammarLift),
-        (
-            RewriteId::LiftLeadingPieceDimension,
-            RewritePhase::GrammarLift,
-        ),
-    ];
-
-    const EXPECTED_REWRITE_LABELS: &[&str] = &[
-        "strip_nbsp",
-        "strip_leading_bullet",
-        "strip_footnote_markers",
-        "strip_trailing_footnote_markers",
-        "split_crossref_optional",
-        "strip_cross_reference",
-        "strip_note_reference",
-        "rewrite_batch_of_to_recipe",
-        "strip_leading_determiner",
-        "strip_minus_equivalence",
-        "strip_total_in_measure_paren",
-        "lift_leading_dimension",
-        "lift_leading_piece_dimension",
-    ];
-
-    #[test]
-    fn rewrite_pipeline_order_is_locked() {
-        let actual: Vec<_> = REWRITES
-            .iter()
-            .map(|rewrite| (rewrite.id, rewrite.phase))
-            .collect();
-        assert_eq!(actual, EXPECTED_REWRITES);
-    }
-
-    #[test]
-    fn rewrite_ids_are_unique() {
-        let ids: HashSet<_> = REWRITES.iter().map(|rewrite| rewrite.id).collect();
-        assert_eq!(ids.len(), REWRITES.len());
-    }
-
-    #[test]
-    fn rewrite_trace_labels_are_stable() {
-        let labels: Vec<_> = REWRITES.iter().map(|rewrite| rewrite.id.as_str()).collect();
-        assert_eq!(labels, EXPECTED_REWRITE_LABELS);
-    }
-
-    #[rstest]
-    // Descriptive aside flanked by name words → lifted out.
-    #[case::temp(
-        "room-temperature (70° to 80°F) water",
-        Some(("room-temperature water", "70° to 80°F"))
-    )]
-    #[case::distance(
-        "sliced (¼ inch / 6 mm) green onions",
-        Some(("sliced green onions", "¼ inch / 6 mm"))
-    )]
-    // Mass/volume parenthetical → left for the amount path.
-    #[case::mass("flour (190 grams) sifted", None)]
-    // The English preposition "in" must not read as the inch unit: only a
-    // number-adjacent "in"/"m" counts as a dimension.
-    #[case::preposition_in("tuna (packed in oil) drained", None)]
-    #[case::number_adjacent_in(
-        "steak (1 in thick) trimmed",
-        Some(("steak trimmed", "1 in thick"))
-    )]
-    // Count + size ("4 (½-inch) slices"): digit before paren, not a name word.
-    #[case::count_size("4 (½-inch) slices pork", None)]
-    // Trailing paren (no name text after) → left for other paths.
-    #[case::trailing("warm water (100°F)", None)]
-    // Leading paren (optional-ingredient shape) → untouched.
-    #[case::leading("(70°F) water", None)]
-    fn test_lift_inline_descriptive_paren(
-        #[case] input: &str,
-        #[case] expected: Option<(&str, &str)>,
-    ) {
-        let got = lift_inline_descriptive_paren(input);
-        assert_eq!(
-            got,
-            expected.map(|(c, a)| (c.to_string(), a.to_string())),
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    #[case::nbsp("1\u{a0}cup\u{a0}flour", "1 cup flour")]
-    #[case::no_nbsp("1 cup flour", "1 cup flour")]
-    fn test_strip_nbsp(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(strip_nbsp(input), expected);
-    }
-
-    #[rstest]
-    // Circled-number footnote markers are dropped.
-    #[case::circled("rye flour \u{2460}", "rye flour ")]
-    #[case::dingbat("salt \u{2776}", "salt ")]
-    // No marker → passes through unchanged.
-    #[case::clean("rye flour", "rye flour")]
-    fn test_strip_footnote_markers(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(strip_footnote_markers(input), expected);
-    }
-
-    #[rstest]
-    // A trailing asterisk/dagger footnote marker is dropped.
-    #[case::asterisk("shredded zucchini (see note)*", "shredded zucchini (see note)")]
-    #[case::dagger("kosher salt \u{2020}", "kosher salt")]
-    #[case::double_dagger("flour\u{2021}", "flour")]
-    // A mid-name asterisk is NOT trailing → left alone.
-    #[case::mid("2% milk", "2% milk")]
-    // No marker → unchanged.
-    #[case::clean("rye flour", "rye flour")]
-    fn test_strip_trailing_footnote_markers(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(strip_trailing_footnote_markers(input), expected);
-    }
-
-    #[rstest]
-    // "the" directly before a quantity is a determiner → dropped.
-    #[case::the_fraction("the ¼ cup of garlic chives", "¼ cup of garlic chives")]
-    #[case::the_digit("the 2 cups flour", "2 cups flour")]
-    // "the" before a word is part of the name → left alone.
-    #[case::the_word("the works seasoning", "the works seasoning")]
-    fn test_strip_leading_determiner(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(strip_leading_determiner(input), expected);
-    }
-
-    #[rstest]
-    // An amount stated elsewhere → the redundant minus-paren is dropped.
-    #[case::redundant(
-        "15 tablespoons (2 sticks minus 1 tablespoon) unsalted butter",
-        "15 tablespoons unsalted butter"
-    )]
-    // Sole-quantity guard: when the minus-paren is the line's ONLY quantity it is
-    // KEPT, so the parse can surface `unparsed_digit` rather than silently zeroing
-    // the amount. (Regression for the minus-equivalence guard.)
-    #[case::sole_quantity(
-        "butter (2 sticks minus 1 tablespoon)",
-        "butter (2 sticks minus 1 tablespoon)"
-    )]
-    // No minus-paren at all → unchanged.
-    #[case::no_paren("2 sticks butter", "2 sticks butter")]
-    fn test_strip_minus_equivalence(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(strip_minus_equivalence(input), expected);
-    }
-
-    #[rstest]
-    // Parenthetical "(optional)" mid/end of a line → stripped, flagged optional.
-    #[case::paren("flour (optional)", "flour", true)]
-    // Trailing ", optional" word form → stripped, flagged.
-    #[case::trailing_word("toasted sesame seeds, optional", "toasted sesame seeds", true)]
-    // Whole-line "(optional)" is left for try_parse_optional_ingredient.
-    #[case::whole_line("(optional)", "(optional)", false)]
-    // No optional marker → unchanged, not flagged.
-    #[case::none("flour", "flour", false)]
-    fn test_strip_optional_note(
-        #[case] input: &str,
-        #[case] expected_text: &str,
-        #[case] expected_flag: bool,
-    ) {
-        let (text, flag) = strip_optional_note(input);
-        assert_eq!(text, expected_text, "text for: {input}");
-        assert_eq!(flag, expected_flag, "flag for: {input}");
-    }
-
-    #[rstest]
-    // Parenthesized leading descriptor → moved to a trailing modifier.
-    #[case::paren_form(
-        "1 (1½-inch-thick) bone-in pork chop (about 1¼ pounds)",
-        "1 bone-in pork chop (about 1¼ pounds), 1½-inch-thick"
-    )]
-    // Bare leading descriptor after a spelled count → moved to the end.
-    #[case::bare_form(
-        "Four ½-inch-thick boneless pork shoulder steaks (2 pounds)",
-        "Four boneless pork shoulder steaks (2 pounds), ½-inch-thick"
-    )]
-    // A size ("10-ounce") ends in a unit, not a shape word → left for the
-    // count+size amount parser, never moved.
-    #[case::size_untouched("1 (10-ounce) can tomatoes", "1 (10-ounce) can tomatoes")]
-    // No leading count → untouched (avoids stealing a mid-line "¼-inch-thick").
-    #[case::no_count(
-        "onion, cut into ¼-inch-thick slices",
-        "onion, cut into ¼-inch-thick slices"
-    )]
-    // A plain dimension ("8-inch") without a shape suffix → untouched.
-    #[case::plain_dimension("1 8-inch cake pan", "1 8-inch cake pan")]
-    fn test_lift_leading_dimension(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            lift_leading_dimension(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    // Bare dimension + container + weight paren → count 1 inserted, dimension
-    // carried to the end so the count+container+weight path can parse.
-    #[case::inch_piece(
-        "1-inch piece (20g) ginger, unpeeled",
-        "1 piece (20g) ginger, unpeeled, 1-inch"
-    )]
-    #[case::vulgar("¾-inch piece (15g) ginger", "1 piece (15g) ginger, ¾-inch")]
-    #[case::range(
-        "1–1½-inch piece (20–30g) ginger, unpeeled",
-        "1 piece (20–30g) ginger, unpeeled, 1–1½-inch"
-    )]
-    #[case::cm_knob("2-cm knob (10g) ginger", "1 knob (10g) ginger, 2-cm")]
-    // No weight paren → bare form parses fine on its own; left untouched.
-    #[case::no_weight("2-inch piece ginger", "2-inch piece ginger")]
-    // A weight size ("10-ounce") ends in a unit, not a distance word → untouched.
-    #[case::weight_size("10-ounce can tomatoes", "10-ounce can tomatoes")]
-    // Second token not a container noun → untouched ("pan" is not a container).
-    #[case::not_container(
-        "9-inch springform (about 23cm) pan",
-        "9-inch springform (about 23cm) pan"
-    )]
-    fn test_lift_leading_piece_dimension(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            lift_leading_piece_dimension(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    // Leading list bullets (en/em-dash, bullet, asterisk) are stripped.
-    #[case::en_dash("– shiitake mushrooms, whole", "shiitake mushrooms, whole")]
-    #[case::em_dash("— bean sprouts", "bean sprouts")]
-    #[case::bullet("• daikon, sliced", "daikon, sliced")]
-    #[case::ascii_hyphen("- firm tofu", "firm tofu")]
-    // A hyphenated leading token (no trailing space after the dash) is untouched.
-    #[case::hyphenated_name("all-purpose flour", "all-purpose flour")]
-    fn test_strip_leading_bullet(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            strip_leading_bullet(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    // "total" inside a measure parenthetical is dropped so the weight can hoist.
-    #[case::pounds("steaks (2 pounds total)", "steaks (2 pounds)")]
-    #[case::in_total("steaks (2 pounds in total)", "steaks (2 pounds)")]
-    // A non-measure parenthetical (no leading number) is left alone.
-    #[case::not_measure("(total recipe)", "(total recipe)")]
-    fn test_strip_total_in_measure_paren(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            strip_total_in_measure_paren(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    // Single page reference (the original cases).
-    #[case::this_page("walnuts (this page)", "walnuts")]
-    #[case::see_this_page("walnuts (see this page),", "walnuts,")]
-    #[case::page_n("flour (page 123)", "flour")]
-    // Chains of page refs joined by connectors (Xi'an Famous Foods).
-    #[case::to_chain("8 dumplings (this page to this page)", "8 dumplings")]
-    #[case::or_list(
-        "1 recipe filling (this page, this page, or this page)",
-        "1 recipe filling"
-    )]
-    // A paren that MIXES a page ref with real content is left alone.
-    #[case::mixed(
-        "8 cups broth (from Lamb Soup, this page)",
-        "8 cups broth (from Lamb Soup, this page)"
-    )]
-    // A page ref mixed with "optional" is left by strip_cross_reference itself —
-    // split_crossref_optional (which runs first) reduces it to "(optional)".
-    #[case::with_optional(
-        "XFF Chili Oil (this page; optional)",
-        "XFF Chili Oil (this page; optional)"
-    )]
-    fn test_strip_cross_reference(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            strip_cross_reference(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    #[case::semicolon("XFF Chili Oil (this page; optional)", "XFF Chili Oil (optional)")]
-    #[case::comma_see_page("flour (see page 12, optional)", "flour (optional)")]
-    // No "optional" → untouched (strip_cross_reference handles the pure ref).
-    #[case::pure_ref("walnuts (this page)", "walnuts (this page)")]
-    // No page ref → untouched (a bare "(optional)" is strip_optional_note's job).
-    #[case::pure_optional("walnuts (optional)", "walnuts (optional)")]
-    fn test_split_crossref_optional(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            split_crossref_optional(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-
-    #[rstest]
-    // "(see note)" / "(note)" headnote cross-refs are dropped.
-    #[case::see_note("shredded zucchini (see note)", "shredded zucchini")]
-    #[case::bare_note("zucchini (note)", "zucchini")]
-    #[case::see_notes("zucchini (see notes)", "zucchini")]
-    // A paren carrying real content is left for the modifier.
-    #[case::real_content("zucchini (note the color)", "zucchini (note the color)")]
-    // No note paren → unchanged.
-    #[case::clean("shredded zucchini", "shredded zucchini")]
-    fn test_strip_note_reference(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(
-            strip_note_reference(input).as_ref(),
-            expected,
-            "input: {input}"
-        );
-    }
-}
+mod tests;

--- a/ingredient-parser/src/parser/normalize/tests.rs
+++ b/ingredient-parser/src/parser/normalize/tests.rs
@@ -1,0 +1,272 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+use rstest::rstest;
+
+#[test]
+fn rewrite_ids_are_unique() {
+    crate::assert_stage_pipeline!(REWRITES);
+}
+
+#[rstest]
+// Descriptive aside flanked by name words → lifted out.
+#[case::temp(
+        "room-temperature (70° to 80°F) water",
+        Some(("room-temperature water", "70° to 80°F"))
+    )]
+#[case::distance(
+        "sliced (¼ inch / 6 mm) green onions",
+        Some(("sliced green onions", "¼ inch / 6 mm"))
+    )]
+// Mass/volume parenthetical → left for the amount path.
+#[case::mass("flour (190 grams) sifted", None)]
+// The English preposition "in" must not read as the inch unit: only a
+// number-adjacent "in"/"m" counts as a dimension.
+#[case::preposition_in("tuna (packed in oil) drained", None)]
+#[case::number_adjacent_in(
+        "steak (1 in thick) trimmed",
+        Some(("steak trimmed", "1 in thick"))
+    )]
+// Count + size ("4 (½-inch) slices"): digit before paren, not a name word.
+#[case::count_size("4 (½-inch) slices pork", None)]
+// Trailing paren (no name text after) → left for other paths.
+#[case::trailing("warm water (100°F)", None)]
+// Leading paren (optional-ingredient shape) → untouched.
+#[case::leading("(70°F) water", None)]
+fn test_lift_inline_descriptive_paren(#[case] input: &str, #[case] expected: Option<(&str, &str)>) {
+    let got = lift_inline_descriptive_paren(input);
+    assert_eq!(
+        got,
+        expected.map(|(c, a)| (c.to_string(), a.to_string())),
+        "input: {input}"
+    );
+}
+
+#[rstest]
+#[case::nbsp("1\u{a0}cup\u{a0}flour", "1 cup flour")]
+#[case::no_nbsp("1 cup flour", "1 cup flour")]
+fn test_strip_nbsp(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(strip_nbsp(input), expected);
+}
+
+#[rstest]
+// Circled-number footnote markers are dropped.
+#[case::circled("rye flour \u{2460}", "rye flour ")]
+#[case::dingbat("salt \u{2776}", "salt ")]
+// No marker → passes through unchanged.
+#[case::clean("rye flour", "rye flour")]
+fn test_strip_footnote_markers(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(strip_footnote_markers(input), expected);
+}
+
+#[rstest]
+// A trailing asterisk/dagger footnote marker is dropped.
+#[case::asterisk("shredded zucchini (see note)*", "shredded zucchini (see note)")]
+#[case::dagger("kosher salt \u{2020}", "kosher salt")]
+#[case::double_dagger("flour\u{2021}", "flour")]
+// A mid-name asterisk is NOT trailing → left alone.
+#[case::mid("2% milk", "2% milk")]
+// No marker → unchanged.
+#[case::clean("rye flour", "rye flour")]
+fn test_strip_trailing_footnote_markers(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(strip_trailing_footnote_markers(input), expected);
+}
+
+#[rstest]
+// "the" directly before a quantity is a determiner → dropped.
+#[case::the_fraction("the ¼ cup of garlic chives", "¼ cup of garlic chives")]
+#[case::the_digit("the 2 cups flour", "2 cups flour")]
+// "the" before a word is part of the name → left alone.
+#[case::the_word("the works seasoning", "the works seasoning")]
+fn test_strip_leading_determiner(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(strip_leading_determiner(input), expected);
+}
+
+#[rstest]
+// An amount stated elsewhere → the redundant minus-paren is dropped.
+#[case::redundant(
+    "15 tablespoons (2 sticks minus 1 tablespoon) unsalted butter",
+    "15 tablespoons unsalted butter"
+)]
+// Sole-quantity guard: when the minus-paren is the line's ONLY quantity it is
+// KEPT, so the parse can surface `unparsed_digit` rather than silently zeroing
+// the amount. (Regression for the minus-equivalence guard.)
+#[case::sole_quantity(
+    "butter (2 sticks minus 1 tablespoon)",
+    "butter (2 sticks minus 1 tablespoon)"
+)]
+// No minus-paren at all → unchanged.
+#[case::no_paren("2 sticks butter", "2 sticks butter")]
+fn test_strip_minus_equivalence(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(strip_minus_equivalence(input), expected);
+}
+
+#[rstest]
+// Parenthetical "(optional)" mid/end of a line → stripped, flagged optional.
+#[case::paren("flour (optional)", "flour", true)]
+// Trailing ", optional" word form → stripped, flagged.
+#[case::trailing_word("toasted sesame seeds, optional", "toasted sesame seeds", true)]
+// Whole-line "(optional)" is left for try_parse_optional_ingredient.
+#[case::whole_line("(optional)", "(optional)", false)]
+// No optional marker → unchanged, not flagged.
+#[case::none("flour", "flour", false)]
+fn test_strip_optional_note(
+    #[case] input: &str,
+    #[case] expected_text: &str,
+    #[case] expected_flag: bool,
+) {
+    let (text, flag) = strip_optional_note(input);
+    assert_eq!(text, expected_text, "text for: {input}");
+    assert_eq!(flag, expected_flag, "flag for: {input}");
+}
+
+#[rstest]
+// Parenthesized leading descriptor → moved to a trailing modifier.
+#[case::paren_form(
+    "1 (1½-inch-thick) bone-in pork chop (about 1¼ pounds)",
+    "1 bone-in pork chop (about 1¼ pounds), 1½-inch-thick"
+)]
+// Bare leading descriptor after a spelled count → moved to the end.
+#[case::bare_form(
+    "Four ½-inch-thick boneless pork shoulder steaks (2 pounds)",
+    "Four boneless pork shoulder steaks (2 pounds), ½-inch-thick"
+)]
+// A size ("10-ounce") ends in a unit, not a shape word → left for the
+// count+size amount parser, never moved.
+#[case::size_untouched("1 (10-ounce) can tomatoes", "1 (10-ounce) can tomatoes")]
+// No leading count → untouched (avoids stealing a mid-line "¼-inch-thick").
+#[case::no_count(
+    "onion, cut into ¼-inch-thick slices",
+    "onion, cut into ¼-inch-thick slices"
+)]
+// A plain dimension ("8-inch") without a shape suffix → untouched.
+#[case::plain_dimension("1 8-inch cake pan", "1 8-inch cake pan")]
+fn test_lift_leading_dimension(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        lift_leading_dimension(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}
+
+#[rstest]
+// Bare dimension + container + weight paren → count 1 inserted, dimension
+// carried to the end so the count+container+weight path can parse.
+#[case::inch_piece(
+    "1-inch piece (20g) ginger, unpeeled",
+    "1 piece (20g) ginger, unpeeled, 1-inch"
+)]
+#[case::vulgar("¾-inch piece (15g) ginger", "1 piece (15g) ginger, ¾-inch")]
+#[case::range(
+    "1–1½-inch piece (20–30g) ginger, unpeeled",
+    "1 piece (20–30g) ginger, unpeeled, 1–1½-inch"
+)]
+#[case::cm_knob("2-cm knob (10g) ginger", "1 knob (10g) ginger, 2-cm")]
+// No weight paren → bare form parses fine on its own; left untouched.
+#[case::no_weight("2-inch piece ginger", "2-inch piece ginger")]
+// A weight size ("10-ounce") ends in a unit, not a distance word → untouched.
+#[case::weight_size("10-ounce can tomatoes", "10-ounce can tomatoes")]
+// Second token not a container noun → untouched ("pan" is not a container).
+#[case::not_container(
+    "9-inch springform (about 23cm) pan",
+    "9-inch springform (about 23cm) pan"
+)]
+fn test_lift_leading_piece_dimension(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        lift_leading_piece_dimension(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}
+
+#[rstest]
+// Leading list bullets (en/em-dash, bullet, asterisk) are stripped.
+#[case::en_dash("– shiitake mushrooms, whole", "shiitake mushrooms, whole")]
+#[case::em_dash("— bean sprouts", "bean sprouts")]
+#[case::bullet("• daikon, sliced", "daikon, sliced")]
+#[case::ascii_hyphen("- firm tofu", "firm tofu")]
+// A hyphenated leading token (no trailing space after the dash) is untouched.
+#[case::hyphenated_name("all-purpose flour", "all-purpose flour")]
+fn test_strip_leading_bullet(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        strip_leading_bullet(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}
+
+#[rstest]
+// "total" inside a measure parenthetical is dropped so the weight can hoist.
+#[case::pounds("steaks (2 pounds total)", "steaks (2 pounds)")]
+#[case::in_total("steaks (2 pounds in total)", "steaks (2 pounds)")]
+// A non-measure parenthetical (no leading number) is left alone.
+#[case::not_measure("(total recipe)", "(total recipe)")]
+fn test_strip_total_in_measure_paren(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        strip_total_in_measure_paren(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}
+
+#[rstest]
+// Single page reference (the original cases).
+#[case::this_page("walnuts (this page)", "walnuts")]
+#[case::see_this_page("walnuts (see this page),", "walnuts,")]
+#[case::page_n("flour (page 123)", "flour")]
+// Chains of page refs joined by connectors (Xi'an Famous Foods).
+#[case::to_chain("8 dumplings (this page to this page)", "8 dumplings")]
+#[case::or_list(
+    "1 recipe filling (this page, this page, or this page)",
+    "1 recipe filling"
+)]
+// A paren that MIXES a page ref with real content is left alone.
+#[case::mixed(
+    "8 cups broth (from Lamb Soup, this page)",
+    "8 cups broth (from Lamb Soup, this page)"
+)]
+// A page ref mixed with "optional" is left by strip_cross_reference itself —
+// split_crossref_optional (which runs first) reduces it to "(optional)".
+#[case::with_optional(
+    "XFF Chili Oil (this page; optional)",
+    "XFF Chili Oil (this page; optional)"
+)]
+fn test_strip_cross_reference(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        strip_cross_reference(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}
+
+#[rstest]
+#[case::semicolon("XFF Chili Oil (this page; optional)", "XFF Chili Oil (optional)")]
+#[case::comma_see_page("flour (see page 12, optional)", "flour (optional)")]
+// No "optional" → untouched (strip_cross_reference handles the pure ref).
+#[case::pure_ref("walnuts (this page)", "walnuts (this page)")]
+// No page ref → untouched (a bare "(optional)" is strip_optional_note's job).
+#[case::pure_optional("walnuts (optional)", "walnuts (optional)")]
+fn test_split_crossref_optional(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        split_crossref_optional(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}
+
+#[rstest]
+// "(see note)" / "(note)" headnote cross-refs are dropped.
+#[case::see_note("shredded zucchini (see note)", "shredded zucchini")]
+#[case::bare_note("zucchini (note)", "zucchini")]
+#[case::see_notes("zucchini (see notes)", "zucchini")]
+// A paren carrying real content is left for the modifier.
+#[case::real_content("zucchini (note the color)", "zucchini (note the color)")]
+// No note paren → unchanged.
+#[case::clean("shredded zucchini", "shredded zucchini")]
+fn test_strip_note_reference(#[case] input: &str, #[case] expected: &str) {
+    assert_eq!(
+        strip_note_reference(input).as_ref(),
+        expected,
+        "input: {input}"
+    );
+}

--- a/ingredient-parser/src/parser/pipeline.rs
+++ b/ingredient-parser/src/parser/pipeline.rs
@@ -273,6 +273,36 @@ impl<'a> GrammarCapture<'a> {
     }
 }
 
+/// Shared ingredient grammar fields. The `values` arm parses measurements and
+/// name chunks directly; the `spans` arm wraps them in `consumed` for field-span
+/// extraction.
+macro_rules! ingredient_grammar_fields {
+    ($mp:ident, values) => {
+        (
+            opt(|a| $mp.parse_measurement_list(a)),
+            space0,
+            opt(|a| $mp.parse_bracketed_amounts(a)),
+            space0,
+            opt(many1(parse_ingredient_text)),
+            opt(|a| $mp.parse_parenthesized_amounts(a)),
+            opt(tag(", ")),
+            not_line_ending,
+        )
+    };
+    ($mp:ident, spans) => {
+        (
+            opt(consumed(|a| $mp.parse_measurement_list(a))),
+            space0,
+            opt(consumed(|a| $mp.parse_bracketed_amounts(a))),
+            space0,
+            opt(consumed(many1(parse_ingredient_text))),
+            opt(consumed(|a| $mp.parse_parenthesized_amounts(a))),
+            opt(tag(", ")),
+            consumed(not_line_ending),
+        )
+    };
+}
+
 /// Shared ingredient grammar (values). Used by [`IngredientParser::parse_ingredient`].
 ///
 /// NOTE: a leading preparation adjective ("1 cup chopped onion") is NOT consumed
@@ -284,27 +314,17 @@ fn parse_ingredient_grammar_values<'a>(
 ) -> Res<&'a str, ParsedIngredient> {
     context(
         "ingredient",
-        (
-            opt(|a| mp.parse_measurement_list(a)),
-            space0,
-            opt(|a| mp.parse_bracketed_amounts(a)),
-            space0,
-            opt(many1(parse_ingredient_text)),
-            opt(|a| mp.parse_parenthesized_amounts(a)),
-            opt(tag(", ")),
-            not_line_ending,
-        )
-            .map(
-                |(primary, _, bracketed, _, name_chunks, paren, _, modifier_text)| {
-                    build_parsed_ingredient(GrammarValues {
-                        primary,
-                        bracketed,
-                        name_chunks,
-                        paren,
-                        modifier: modifier_text,
-                    })
-                },
-            ),
+        ingredient_grammar_fields!(mp, values).map(
+            |(primary, _, bracketed, _, name_chunks, paren, _, modifier_text)| {
+                build_parsed_ingredient(GrammarValues {
+                    primary,
+                    bracketed,
+                    name_chunks,
+                    paren,
+                    modifier: modifier_text,
+                })
+            },
+        ),
     )
     .parse(input)
 }
@@ -317,38 +337,21 @@ fn parse_ingredient_grammar_spans<'a>(
 ) -> Res<&'a str, GrammarCapture<'a>> {
     context(
         "ingredient",
-        (
-            opt(consumed(|a| mp.parse_measurement_list(a))),
-            space0,
-            opt(consumed(|a| mp.parse_bracketed_amounts(a))),
-            space0,
-            opt(consumed(many1(parse_ingredient_text))),
-            opt(consumed(|a| mp.parse_parenthesized_amounts(a))),
-            opt(tag(", ")),
-            consumed(not_line_ending),
-        )
-            .map(
-                |(primary, _, bracketed, _, name, paren, _, (modifier, _))| GrammarCapture {
-                    primary,
-                    bracketed,
-                    name,
-                    paren,
-                    modifier,
-                },
-            ),
+        ingredient_grammar_fields!(mp, spans).map(
+            |(primary, _, bracketed, _, name, paren, _, (modifier, _))| GrammarCapture {
+                primary,
+                bracketed,
+                name,
+                paren,
+                modifier,
+            },
+        ),
     )
     .parse(input)
 }
 
 fn fallback_ingredient(input: &str) -> Ingredient {
-    Ingredient {
-        name: input.trim().to_string(),
-        amounts: vec![],
-        modifier: None,
-        optional: false,
-        usage: Default::default(),
-        parse_notes: Default::default(),
-    }
+    Ingredient::from_parser_parts(input.trim(), vec![], None, false)
 }
 
 fn raw_name(name_chunks: Option<Vec<&str>>) -> String {

--- a/ingredient-parser/src/parser/recognize.rs
+++ b/ingredient-parser/src/parser/recognize.rs
@@ -15,23 +15,10 @@ impl IngredientParser {
     /// that matches (or `None` to fall through to the core parse).
     pub(super) fn run_recognizers(&self, input: &str) -> Option<Ingredient> {
         RECOGNIZERS.iter().find_map(|recognizer| {
-            let _phase = recognizer.phase;
-            if !crate::trace::is_tracing_enabled() {
-                return (recognizer.run)(self, input);
-            }
-            // Trace each recognizer attempt so the egui tree shows which matched
-            // (and which were skipped).
-            crate::trace::trace_enter(recognizer.id.as_str(), input);
-            match (recognizer.run)(self, input) {
-                Some(ingredient) => {
-                    crate::trace::trace_exit_success(0, &ingredient.name);
-                    Some(ingredient)
-                }
-                None => {
-                    crate::trace::trace_exit_failure("no match");
-                    None
-                }
-            }
+            let result = (recognizer.run)(self, input);
+            crate::trace::trace_attempt(recognizer.id().as_str(), input, result, |ingredient| {
+                ingredient.name.clone()
+            })
         })
     }
 
@@ -83,14 +70,12 @@ impl IngredientParser {
                 continue;
             }
 
-            return Some(Ingredient {
-                name: name_part.trim().to_string(),
+            return Some(Ingredient::from_parser_parts(
+                name_part.trim(),
                 amounts,
-                modifier: None,
-                optional: false,
-                usage: Default::default(),
-                parse_notes: Default::default(),
-            });
+                None,
+                false,
+            ));
         }
 
         None
@@ -108,14 +93,7 @@ impl IngredientParser {
         // Find the leading "… of " / "… from " clause whose pivot is immediately
         // followed by a number (e.g. "Seeds scraped from 1 …"). Uses the EARLIEST
         // qualifying pivot across both separators.
-        let lower = trimmed.to_lowercase();
-        // Lowercasing can change byte lengths for some Unicode (e.g. 'İ' ->
-        // "i̇"), so offsets found in `lower` would misalign with `trimmed` and
-        // slicing could split a char (panic). Bail for such rare inputs, the
-        // same defense extract_adjectives_from_name uses.
-        if lower.len() != trimmed.len() {
-            return None;
-        }
+        let lower = crate::parser::byte_aligned_lowercase(trimmed)?;
         let pivot_end = [" of ", " from "]
             .iter()
             .filter_map(|sep| {
@@ -167,78 +145,24 @@ impl IngredientParser {
 /// `Ingredient` when the line has its particular shape, else `None`.
 type Recognizer = fn(&IngredientParser, &str) -> Option<Ingredient>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum RecognizerId {
-    OptionalWrapped,
-    TrailingAmount,
-    XOfConstruction,
-}
-
-impl RecognizerId {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            RecognizerId::OptionalWrapped => "optional_wrapped",
-            RecognizerId::TrailingAmount => "trailing_amount",
-            RecognizerId::XOfConstruction => "x_of_construction",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum RecognizerPhase {
-    Wrapper,
-    AmountPosition,
-    DerivedPart,
-}
-
-#[derive(Clone, Copy)]
-struct RecognizerEntry {
-    id: RecognizerId,
-    phase: RecognizerPhase,
-    run: Recognizer,
-}
-
-impl RecognizerEntry {
-    const fn new(id: RecognizerId, phase: RecognizerPhase, run: Recognizer) -> Self {
-        Self { id, phase, run }
-    }
-}
-
-/// The ordered recognizer list, tried first-match before the core parse. Order
-/// matters: the optional-wrapped check must precede the others (it strips the
-/// outer parens), and x-of-construction is last (most permissive).
-//
-// TODO(parse_multi): an "X and Y" line with two distinct heads ("Kosher salt
-// and freshly ground black pepper") — and a no-quantity "X or Y" contrast
-// ("fresh or frozen blueberries") — is really TWO ingredients. There is no
-// multi-ingredient splitter yet, so `from_str` returns a single Ingredient:
-// refine's " and " guard keeps the and-line as one clean name (rather than
-// doing mid-seam adjective surgery), and the or-line keeps its reconstructed
-// primary + alternative. A future `parse_multi` recognizer would split these
-// into a `Vec<Ingredient>`. Corpus rows for these carry a matching TODO.
-const RECOGNIZERS: &[RecognizerEntry] = &[
-    RecognizerEntry::new(
-        RecognizerId::OptionalWrapped,
-        RecognizerPhase::Wrapper,
-        IngredientParser::try_parse_optional_ingredient,
+crate::define_stage_pipeline! {
+    pub(crate) enum RecognizerId,
+    struct RecognizerEntry,
+    const RECOGNIZERS: &[RecognizerEntry],
+    type Recognizer = Recognizer,
+    trace: pub(crate) RECOGNIZER_TRACE_NAMES,
+    (OptionalWrapped, "optional_wrapped", IngredientParser::try_parse_optional_ingredient),
+    (
+        TrailingAmount,
+        "trailing_amount",
+        IngredientParser::try_parse_trailing_amount_format
     ),
-    RecognizerEntry::new(
-        RecognizerId::TrailingAmount,
-        RecognizerPhase::AmountPosition,
-        IngredientParser::try_parse_trailing_amount_format,
+    (
+        XOfConstruction,
+        "x_of_construction",
+        IngredientParser::try_parse_x_of_construction
     ),
-    RecognizerEntry::new(
-        RecognizerId::XOfConstruction,
-        RecognizerPhase::DerivedPart,
-        IngredientParser::try_parse_x_of_construction,
-    ),
-];
-
-pub(crate) const RECOGNIZER_TRACE_NAMES: &[&str] = &[
-    RecognizerId::OptionalWrapped.as_str(),
-    RecognizerId::TrailingAmount.as_str(),
-    RecognizerId::XOfConstruction.as_str(),
-];
+}
 
 fn is_temperature_unit(unit: &unit::Unit) -> bool {
     matches!(unit, unit::Unit::Fahrenheit | unit::Unit::Celsius)
@@ -249,43 +173,10 @@ fn is_temperature_unit(unit: &unit::Unit) -> bool {
 mod tests {
     use super::*;
     use rstest::rstest;
-    use std::collections::HashSet;
-
-    const EXPECTED_RECOGNIZERS: &[(RecognizerId, RecognizerPhase)] = &[
-        (RecognizerId::OptionalWrapped, RecognizerPhase::Wrapper),
-        (
-            RecognizerId::TrailingAmount,
-            RecognizerPhase::AmountPosition,
-        ),
-        (RecognizerId::XOfConstruction, RecognizerPhase::DerivedPart),
-    ];
-
-    const EXPECTED_RECOGNIZER_LABELS: &[&str] =
-        &["optional_wrapped", "trailing_amount", "x_of_construction"];
-
-    #[test]
-    fn recognizer_order_is_locked() {
-        let actual: Vec<_> = RECOGNIZERS
-            .iter()
-            .map(|recognizer| (recognizer.id, recognizer.phase))
-            .collect();
-        assert_eq!(actual, EXPECTED_RECOGNIZERS);
-    }
 
     #[test]
     fn recognizer_ids_are_unique() {
-        let ids: HashSet<_> = RECOGNIZERS.iter().map(|recognizer| recognizer.id).collect();
-        assert_eq!(ids.len(), RECOGNIZERS.len());
-    }
-
-    #[test]
-    fn recognizer_trace_labels_are_stable() {
-        let labels: Vec<_> = RECOGNIZERS
-            .iter()
-            .map(|recognizer| recognizer.id.as_str())
-            .collect();
-        assert_eq!(labels, EXPECTED_RECOGNIZER_LABELS);
-        assert_eq!(RECOGNIZER_TRACE_NAMES, EXPECTED_RECOGNIZER_LABELS);
+        crate::assert_stage_pipeline!(RECOGNIZERS);
     }
 
     // ── try_parse_optional_ingredient ───────────────────────────────────────

--- a/ingredient-parser/src/parser/refine.rs
+++ b/ingredient-parser/src/parser/refine.rs
@@ -39,28 +39,23 @@ impl IngredientParser {
     }
 
     fn run_refine_pass(&self, pass: &RefinePass, parsed: &mut ParsedIngredient) {
-        let RefinePass {
-            id,
-            phase: _phase,
-            run,
-        } = *pass;
-        if crate::trace::is_tracing_enabled() {
-            let before = parsed.clone();
+        let RefinePass { run, .. } = *pass;
+        if !crate::trace::is_tracing_enabled() {
             run(self, parsed);
-            if *parsed != before {
-                crate::trace::trace_enter(id.as_str(), &before.name);
-                crate::trace::trace_exit_success(
-                    0,
-                    &format!(
-                        "{} | {}",
-                        parsed.name,
-                        parsed.modifier_string().as_deref().unwrap_or("-")
-                    ),
-                );
-            }
-        } else {
-            run(self, parsed);
+            return;
         }
+        let before = parsed.clone();
+        run(self, parsed);
+        crate::trace::trace_on_change(
+            pass.id().as_str(),
+            &before.name,
+            &format!(
+                "{} | {}",
+                parsed.name,
+                parsed.modifier_string().as_deref().unwrap_or("-")
+            ),
+            *parsed != before,
+        );
     }
 
     /// Collapse runs of whitespace left in the name by earlier passes. A pass in
@@ -73,170 +68,89 @@ impl IngredientParser {
 
 type Pass = fn(&IngredientParser, &mut ParsedIngredient);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(super) enum PassId {
-    FixLeadingPrepPhrase,
-    FixLeadingMinusClause,
-    ExtractPostfixProduceUnit,
-    ExtractSizeUnitFromName,
-    ExtractLeadingPrepAlternative,
-    ExtractTrailingPrepClause,
-    RecoverHeadNounFromModifier,
-    ExtractAdjectivesFromName,
-    CollapseName,
-    ExtractPurposeGerund,
-    ExtractAlternativeFromName,
-    ExtractWordAlternativeFromName,
-    ExtractAndOrAlternativeFromName,
-    RecoverParentheticalAliasFromModifier,
-    RecoverSharedHeadFromAlternatives,
-    ExtractSecondaryAmountsFromModifier,
+crate::define_stage_pipeline! {
+    pub(super) enum PassId,
+    pub(super) struct RefinePass,
+    pub(super) const REFINE_PIPELINE: &[RefinePass],
+    type Pass = Pass,
+    trace: none,
+    (
+        FixLeadingPrepPhrase,
+        "fix_leading_prep_phrase",
+        IngredientParser::fix_leading_prep_phrase
+    ),
+    (
+        FixLeadingMinusClause,
+        "fix_leading_minus_clause",
+        IngredientParser::fix_leading_minus_clause
+    ),
+    (
+        ExtractPostfixProduceUnit,
+        "extract_postfix_produce_unit",
+        IngredientParser::extract_postfix_produce_unit
+    ),
+    (
+        ExtractSizeUnitFromName,
+        "extract_size_unit_from_name",
+        IngredientParser::extract_size_unit_from_name
+    ),
+    (
+        ExtractLeadingPrepAlternative,
+        "extract_leading_prep_alternative",
+        IngredientParser::extract_leading_prep_alternative
+    ),
+    (
+        ExtractTrailingPrepClause,
+        "extract_trailing_prep_clause",
+        IngredientParser::extract_trailing_prep_clause
+    ),
+    (
+        RecoverHeadNounFromModifier,
+        "recover_head_noun_from_modifier",
+        IngredientParser::recover_head_noun_from_modifier
+    ),
+    (
+        ExtractAdjectivesFromName,
+        "extract_adjectives_from_name",
+        IngredientParser::extract_adjectives_from_name
+    ),
+    (CollapseName, "collapse_name", IngredientParser::collapse_name),
+    (
+        ExtractPurposeGerund,
+        "extract_purpose_gerund",
+        IngredientParser::extract_purpose_gerund
+    ),
+    (
+        ExtractAlternativeFromName,
+        "extract_alternative_from_name",
+        IngredientParser::extract_alternative_from_name
+    ),
+    (
+        ExtractWordAlternativeFromName,
+        "extract_word_alternative_from_name",
+        IngredientParser::extract_word_alternative_from_name
+    ),
+    (
+        ExtractAndOrAlternativeFromName,
+        "extract_and_or_alternative_from_name",
+        IngredientParser::extract_and_or_alternative_from_name
+    ),
+    (
+        RecoverParentheticalAliasFromModifier,
+        "recover_parenthetical_alias_from_modifier",
+        IngredientParser::recover_parenthetical_alias_from_modifier
+    ),
+    (
+        RecoverSharedHeadFromAlternatives,
+        "recover_shared_head_from_alternatives",
+        IngredientParser::recover_shared_head_from_alternatives
+    ),
+    (
+        ExtractSecondaryAmountsFromModifier,
+        "extract_secondary_amounts_from_modifier",
+        IngredientParser::extract_secondary_amounts_from_modifier
+    ),
 }
-
-impl PassId {
-    pub(super) const fn as_str(self) -> &'static str {
-        match self {
-            PassId::FixLeadingPrepPhrase => "fix_leading_prep_phrase",
-            PassId::FixLeadingMinusClause => "fix_leading_minus_clause",
-            PassId::ExtractPostfixProduceUnit => "extract_postfix_produce_unit",
-            PassId::ExtractSizeUnitFromName => "extract_size_unit_from_name",
-            PassId::ExtractLeadingPrepAlternative => "extract_leading_prep_alternative",
-            PassId::ExtractTrailingPrepClause => "extract_trailing_prep_clause",
-            PassId::RecoverHeadNounFromModifier => "recover_head_noun_from_modifier",
-            PassId::ExtractAdjectivesFromName => "extract_adjectives_from_name",
-            PassId::CollapseName => "collapse_name",
-            PassId::ExtractPurposeGerund => "extract_purpose_gerund",
-            PassId::ExtractAlternativeFromName => "extract_alternative_from_name",
-            PassId::ExtractWordAlternativeFromName => "extract_word_alternative_from_name",
-            PassId::ExtractAndOrAlternativeFromName => "extract_and_or_alternative_from_name",
-            PassId::RecoverParentheticalAliasFromModifier => {
-                "recover_parenthetical_alias_from_modifier"
-            }
-            PassId::RecoverSharedHeadFromAlternatives => "recover_shared_head_from_alternatives",
-            PassId::ExtractSecondaryAmountsFromModifier => {
-                "extract_secondary_amounts_from_modifier"
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(super) enum RefinePhase {
-    Recover,
-    Units,
-    Prep,
-    Alternatives,
-    Amounts,
-    Cleanup,
-}
-
-#[derive(Clone, Copy)]
-pub(super) struct RefinePass {
-    id: PassId,
-    phase: RefinePhase,
-    run: Pass,
-}
-
-impl RefinePass {
-    const fn new(id: PassId, phase: RefinePhase, run: Pass) -> Self {
-        Self { id, phase, run }
-    }
-}
-
-/// The ordered refinement pipeline. The order is load-bearing — e.g. whitespace
-/// is collapsed *between* adjective and alternative extraction. The modifier is
-/// finalized when the IR is lowered to `Ingredient`. Adding or reordering a step
-/// is a one-line edit here.
-///
-/// Critical ordering dependencies (see `refine_pipeline_order_invariants` test):
-/// - `ExtractAdjectivesFromName` before alternative passes — prep words must leave
-///   the name before "or …" / "and …" alternative extraction runs.
-/// - `CollapseName` between adjective and alternative extraction — whitespace
-///   normalization must not run before adjectives are peeled.
-/// - `ExtractSecondaryAmountsFromModifier` last — hoists parenthetical amounts
-///   after all modifier text shaping is finished.
-pub(super) const REFINE_PIPELINE: &[RefinePass] = &[
-    RefinePass::new(
-        PassId::FixLeadingPrepPhrase,
-        RefinePhase::Recover,
-        IngredientParser::fix_leading_prep_phrase,
-    ),
-    RefinePass::new(
-        PassId::FixLeadingMinusClause,
-        RefinePhase::Recover,
-        IngredientParser::fix_leading_minus_clause,
-    ),
-    RefinePass::new(
-        PassId::ExtractPostfixProduceUnit,
-        RefinePhase::Units,
-        IngredientParser::extract_postfix_produce_unit,
-    ),
-    RefinePass::new(
-        PassId::ExtractSizeUnitFromName,
-        RefinePhase::Units,
-        IngredientParser::extract_size_unit_from_name,
-    ),
-    RefinePass::new(
-        PassId::ExtractLeadingPrepAlternative,
-        RefinePhase::Alternatives,
-        IngredientParser::extract_leading_prep_alternative,
-    ),
-    RefinePass::new(
-        PassId::ExtractTrailingPrepClause,
-        RefinePhase::Prep,
-        IngredientParser::extract_trailing_prep_clause,
-    ),
-    RefinePass::new(
-        PassId::RecoverHeadNounFromModifier,
-        RefinePhase::Recover,
-        IngredientParser::recover_head_noun_from_modifier,
-    ),
-    RefinePass::new(
-        PassId::ExtractAdjectivesFromName,
-        RefinePhase::Prep,
-        IngredientParser::extract_adjectives_from_name,
-    ),
-    RefinePass::new(
-        PassId::CollapseName,
-        RefinePhase::Cleanup,
-        IngredientParser::collapse_name,
-    ),
-    RefinePass::new(
-        PassId::ExtractPurposeGerund,
-        RefinePhase::Prep,
-        IngredientParser::extract_purpose_gerund,
-    ),
-    RefinePass::new(
-        PassId::ExtractAlternativeFromName,
-        RefinePhase::Alternatives,
-        IngredientParser::extract_alternative_from_name,
-    ),
-    RefinePass::new(
-        PassId::ExtractWordAlternativeFromName,
-        RefinePhase::Alternatives,
-        IngredientParser::extract_word_alternative_from_name,
-    ),
-    RefinePass::new(
-        PassId::ExtractAndOrAlternativeFromName,
-        RefinePhase::Alternatives,
-        IngredientParser::extract_and_or_alternative_from_name,
-    ),
-    RefinePass::new(
-        PassId::RecoverParentheticalAliasFromModifier,
-        RefinePhase::Recover,
-        IngredientParser::recover_parenthetical_alias_from_modifier,
-    ),
-    RefinePass::new(
-        PassId::RecoverSharedHeadFromAlternatives,
-        RefinePhase::Alternatives,
-        IngredientParser::recover_shared_head_from_alternatives,
-    ),
-    RefinePass::new(
-        PassId::ExtractSecondaryAmountsFromModifier,
-        RefinePhase::Amounts,
-        IngredientParser::extract_secondary_amounts_from_modifier,
-    ),
-];
 
 /// Strip a single pair of parentheses that wraps the *entire* modifier, e.g.
 /// "(softened)" -> "softened". Modifiers with internal parentheses or only
@@ -266,645 +180,4 @@ pub(super) fn clean_modifier(modifier: Option<String>) -> Option<String> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-    use std::collections::HashSet;
-
-    const EXPECTED_PIPELINE: &[(PassId, RefinePhase)] = &[
-        (PassId::FixLeadingPrepPhrase, RefinePhase::Recover),
-        (PassId::FixLeadingMinusClause, RefinePhase::Recover),
-        (PassId::ExtractPostfixProduceUnit, RefinePhase::Units),
-        (PassId::ExtractSizeUnitFromName, RefinePhase::Units),
-        (
-            PassId::ExtractLeadingPrepAlternative,
-            RefinePhase::Alternatives,
-        ),
-        (PassId::ExtractTrailingPrepClause, RefinePhase::Prep),
-        (PassId::RecoverHeadNounFromModifier, RefinePhase::Recover),
-        (PassId::ExtractAdjectivesFromName, RefinePhase::Prep),
-        (PassId::CollapseName, RefinePhase::Cleanup),
-        (PassId::ExtractPurposeGerund, RefinePhase::Prep),
-        (
-            PassId::ExtractAlternativeFromName,
-            RefinePhase::Alternatives,
-        ),
-        (
-            PassId::ExtractWordAlternativeFromName,
-            RefinePhase::Alternatives,
-        ),
-        (
-            PassId::ExtractAndOrAlternativeFromName,
-            RefinePhase::Alternatives,
-        ),
-        (
-            PassId::RecoverParentheticalAliasFromModifier,
-            RefinePhase::Recover,
-        ),
-        (
-            PassId::RecoverSharedHeadFromAlternatives,
-            RefinePhase::Alternatives,
-        ),
-        (
-            PassId::ExtractSecondaryAmountsFromModifier,
-            RefinePhase::Amounts,
-        ),
-    ];
-
-    const EXPECTED_TRACE_LABELS: &[&str] = &[
-        "fix_leading_prep_phrase",
-        "fix_leading_minus_clause",
-        "extract_postfix_produce_unit",
-        "extract_size_unit_from_name",
-        "extract_leading_prep_alternative",
-        "extract_trailing_prep_clause",
-        "recover_head_noun_from_modifier",
-        "extract_adjectives_from_name",
-        "collapse_name",
-        "extract_purpose_gerund",
-        "extract_alternative_from_name",
-        "extract_word_alternative_from_name",
-        "extract_and_or_alternative_from_name",
-        "recover_parenthetical_alias_from_modifier",
-        "recover_shared_head_from_alternatives",
-        "extract_secondary_amounts_from_modifier",
-    ];
-
-    #[test]
-    fn refine_pipeline_order_is_locked() {
-        let actual: Vec<_> = REFINE_PIPELINE
-            .iter()
-            .map(|pass| (pass.id, pass.phase))
-            .collect();
-        assert_eq!(actual, EXPECTED_PIPELINE);
-    }
-
-    #[test]
-    fn refine_pipeline_pass_ids_are_unique() {
-        let ids: HashSet<_> = REFINE_PIPELINE.iter().map(|pass| pass.id).collect();
-        assert_eq!(ids.len(), REFINE_PIPELINE.len());
-    }
-
-    #[test]
-    fn refine_pipeline_trace_labels_are_stable() {
-        let labels: Vec<_> = REFINE_PIPELINE
-            .iter()
-            .map(|pass| pass.id.as_str())
-            .collect();
-        assert_eq!(labels, EXPECTED_TRACE_LABELS);
-    }
-
-    fn pass_index(id: PassId) -> usize {
-        REFINE_PIPELINE
-            .iter()
-            .position(|pass| pass.id == id)
-            .expect("REFINE_PIPELINE missing expected pass")
-    }
-
-    #[test]
-    fn refine_pipeline_order_invariants() {
-        // Prep adjectives must leave the name before any alternative extraction.
-        assert!(
-            pass_index(PassId::ExtractAdjectivesFromName)
-                < pass_index(PassId::ExtractAlternativeFromName),
-            "adjectives before alternatives"
-        );
-        assert!(
-            pass_index(PassId::ExtractAdjectivesFromName)
-                < pass_index(PassId::ExtractWordAlternativeFromName),
-            "adjectives before word alternatives"
-        );
-        assert!(
-            pass_index(PassId::ExtractAdjectivesFromName)
-                < pass_index(PassId::ExtractAndOrAlternativeFromName),
-            "adjectives before and/or alternatives"
-        );
-        // Whitespace collapse sits between adjective peel and alternative passes.
-        assert!(
-            pass_index(PassId::ExtractAdjectivesFromName) < pass_index(PassId::CollapseName),
-            "adjectives before collapse"
-        );
-        assert!(
-            pass_index(PassId::CollapseName) < pass_index(PassId::ExtractAlternativeFromName),
-            "collapse before alternatives"
-        );
-        // Parenthetical amount hoists run after modifier text is fully shaped.
-        assert!(
-            pass_index(PassId::ExtractSecondaryAmountsFromModifier) == REFINE_PIPELINE.len() - 1,
-            "secondary amounts must be last"
-        );
-    }
-
-    #[rstest]
-    // Fully wrapped: outer parens are stripped.
-    #[case::simple("(sifted)", Some("sifted"))]
-    #[case::with_percent("(70% cacao)", Some("70% cacao"))]
-    #[case::inner_trimmed("(  softened  )", Some("softened"))]
-    // Not wrapped, or only partially: left untouched.
-    #[case::plain("softened", Some("softened"))]
-    #[case::open_only("(partial", Some("(partial"))]
-    #[case::close_only("partial)", Some("partial)"))]
-    // Internal parens must NOT be collapsed (would merge distinct clauses).
-    #[case::two_groups("(a) and (b)", Some("(a) and (b)"))]
-    #[case::nested("(note (nested))", Some("(note (nested))"))]
-    // An empty group collapses away entirely.
-    #[case::empty("()", None)]
-    fn test_strip_wrapping_parens(#[case] input: &str, #[case] expected: Option<&str>) {
-        assert_eq!(
-            strip_wrapping_parens(Some(input.to_string())),
-            expected.map(str::to_string)
-        );
-    }
-
-    #[test]
-    fn test_strip_wrapping_parens_none() {
-        assert_eq!(strip_wrapping_parens(None), None);
-    }
-
-    // ------------------------------------------------------------------
-    // Per-pass guard tests. These exercise the subtle conditions in each
-    // refine pass directly (previously only covered end-to-end by the
-    // accuracy corpus), so a regression points at the exact pass.
-    // ------------------------------------------------------------------
-
-    fn ing(name: &str, modifier: Option<&str>) -> ParsedIngredient {
-        ParsedIngredient {
-            name: name.to_string(),
-            amounts: vec![],
-            modifier: modifier
-                .map(|m| vec![ModifierPart::Raw(m.to_string())])
-                .unwrap_or_default(),
-            optional: false,
-        }
-    }
-
-    /// A name that is exactly a known prep phrase swaps with the modifier; a
-    /// descriptive name is left alone (the exact-match guard).
-    #[rstest]
-    #[case::swaps(
-        "finely chopped",
-        Some("raw pistachios"),
-        "raw pistachios",
-        Some("finely chopped")
-    )]
-    #[case::no_swap_descriptive(
-        "raw pistachios",
-        Some("finely chopped"),
-        "raw pistachios",
-        Some("finely chopped")
-    )]
-    #[case::no_swap_no_modifier("chopped", None, "chopped", None)]
-    fn test_fix_leading_prep_phrase(
-        #[case] name: &str,
-        #[case] modifier: Option<&str>,
-        #[case] want_name: &str,
-        #[case] want_modifier: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, modifier);
-        parser.fix_leading_prep_phrase(&mut i);
-        assert_eq!(i.name, want_name);
-        assert_eq!(i.modifier_string().as_deref(), want_modifier);
-    }
-
-    /// "minus <measure> <name>" moves the subtractive clause to the modifier and
-    /// restores the real name.
-    #[test]
-    fn test_fix_leading_minus_clause() {
-        let parser = IngredientParser::new();
-        let mut i = ing("minus 1 tablespoon flour", None);
-        parser.fix_leading_minus_clause(&mut i);
-        assert_eq!(i.name, "flour");
-        assert_eq!(i.modifier_string().as_deref(), Some("minus 1 tablespoon"));
-    }
-
-    /// Adjectives are pulled from the name into the modifier, but only on word
-    /// boundaries (so "well-chopped" is left intact).
-    #[rstest]
-    #[case::extracts("chopped onion", "onion", Some("chopped"))]
-    #[case::boundary_guard("well-chopped onion", "well-chopped onion", None)]
-    // Two adjectives in one name exercise the loop's name/name_lower rebuild.
-    #[case::two_adjectives("chopped sifted flour", "flour", Some("chopped, sifted"))]
-    // An adjective inside an "or" alternative is left for the alternative
-    // passes ("chopped" describes parsley, not basil). One before "or" is
-    // still extracted.
-    #[case::after_or_left_alone("basil or chopped parsley", "basil or chopped parsley", None)]
-    #[case::before_or_extracted("chopped basil or parsley", "basil or parsley", Some("chopped"))]
-    // " and " guard: a mid-seam adjective belongs to the second conjunct and is
-    // left in the name (it's really two ingredients — a parse_multi concern)…
-    #[case::and_guard_keeps_conjunct(
-        "Kosher salt and freshly ground black pepper",
-        "Kosher salt and freshly ground black pepper",
-        None
-    )]
-    // …but a TRAILING phrase after "and" (end-of-string) is still extracted.
-    #[case::and_trailing_extracted("Salt and pepper to taste", "Salt and pepper", Some("to taste"))]
-    // bare "grated" extracts; "fresh" (implied default) extracts…
-    #[case::grated_extracts("grated lemon zest", "lemon zest", Some("grated"))]
-    #[case::cubed_extracts("cubed seedless watermelon", "seedless watermelon", Some("cubed"))]
-    #[case::fresh_extracts("fresh mint", "mint", Some("fresh"))]
-    // …except "fresh or frozen" — a genuine contrast — keeps "fresh" in the name.
-    #[case::fresh_or_kept("fresh or frozen blueberries", "fresh or frozen blueberries", None)]
-    fn test_extract_adjectives_from_name(
-        #[case] name: &str,
-        #[case] want_name: &str,
-        #[case] want_modifier: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, None);
-        parser.extract_adjectives_from_name(&mut i);
-        assert_eq!(i.name, want_name);
-        assert_eq!(i.modifier_string().as_deref(), want_modifier);
-    }
-
-    /// A leading "<participle> or <adjective> <noun>" prep alternative moves to
-    /// the modifier; a genuine two-ingredient alternative is left alone.
-    #[rstest]
-    #[case::prep_alt("grated or finely chopped lemon zest", "lemon zest", true)]
-    #[case::genuine_alt("basil or chopped parsley", "basil or chopped parsley", false)]
-    fn test_extract_leading_prep_alternative(
-        #[case] name: &str,
-        #[case] want_name: &str,
-        #[case] moved: bool,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, None);
-        parser.extract_leading_prep_alternative(&mut i);
-        assert_eq!(i.name, want_name);
-        assert_eq!(i.modifier_string().is_some(), moved, "name: {name}");
-    }
-
-    #[rstest]
-    #[case::plain("thyme and/or rosemary", None, "thyme", Some("and/or rosemary"))]
-    #[case::before_raw(
-        "cilantro and/or mint",
-        Some("for serving"),
-        "cilantro",
-        Some("and/or mint, for serving")
-    )]
-    fn test_extract_and_or_alternative_from_name(
-        #[case] name: &str,
-        #[case] modifier: Option<&str>,
-        #[case] want_name: &str,
-        #[case] want_modifier: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, modifier);
-        parser.extract_and_or_alternative_from_name(&mut i);
-        assert_eq!(i.name, want_name);
-        assert_eq!(i.modifier_string().as_deref(), want_modifier);
-    }
-
-    #[rstest]
-    #[case::recovers_alias(
-        "purple",
-        Some("(red) cabbage (about 1 pound)"),
-        "purple (red) cabbage",
-        Some("(about 1 pound)")
-    )]
-    #[case::non_alias_amount_left_alone(
-        "cabbage",
-        Some("(about 1 pound)"),
-        "cabbage",
-        Some("(about 1 pound)")
-    )]
-    fn test_recover_parenthetical_alias_from_modifier(
-        #[case] name: &str,
-        #[case] modifier: Option<&str>,
-        #[case] want_name: &str,
-        #[case] want_modifier: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, modifier);
-        parser.recover_parenthetical_alias_from_modifier(&mut i);
-        assert_eq!(i.name, want_name);
-        assert_eq!(i.modifier_string().as_deref(), want_modifier);
-    }
-
-    /// "(about N unit)" in the modifier hoists a secondary amount; a distance
-    /// aside ("(about 3-inch)") is a shape descriptor and is left in place.
-    #[rstest]
-    #[case::hoists("chopped (about 2 cups)", 1)]
-    #[case::distance_kept("cut into (about 3-inch) strips", 0)]
-    // A bare trailing weight parenthetical hoists both measures (oz + g).
-    #[case::trailing_weight("coarsely chopped (2.1 oz / 60g)", 2)]
-    // A non-measure trailing parenthetical is left in place.
-    #[case::non_measure("chopped (softened)", 0)]
-    fn test_extract_secondary_amounts_from_modifier(
-        #[case] modifier: &str,
-        #[case] want_amounts: usize,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing("scallions", Some(modifier));
-        parser.extract_secondary_amounts_from_modifier(&mut i);
-        assert_eq!(i.amounts.len(), want_amounts, "modifier: {modifier}");
-    }
-
-    /// A MID-modifier hoist must not leave a doubled internal space where the
-    /// parenthetical was excised (trim only fixes the ends).
-    #[test]
-    fn test_extract_secondary_amounts_mid_modifier_whitespace() {
-        let parser = IngredientParser::new();
-        let mut i = ing(
-            "parsley",
-            Some("chopped (about 2 cups) plus more for garnish"),
-        );
-        parser.extract_secondary_amounts_from_modifier(&mut i);
-        assert_eq!(i.amounts.len(), 1);
-        assert_eq!(
-            i.modifier_string().as_deref(),
-            Some("chopped plus more for garnish")
-        );
-    }
-
-    /// A no-quantity "X or Y" alternative is split out of the name, with the head
-    /// noun reconstructed onto the primary when the left side is a lone adjective.
-    #[rstest]
-    // Lone adjective before "or": head noun shared onto the primary.
-    #[case::shared_head("red or white onion", "red onion", Some("or white onion"))]
-    #[case::shared_multiword_head(
-        "fresh or frozen pitted sweet cherries",
-        "fresh pitted sweet cherries",
-        Some("or frozen pitted sweet cherries")
-    )]
-    // Distinct nouns (single- or multi-word left): primary = left, no reconstruct.
-    #[case::distinct_noun("flour or cornmeal", "flour", Some("or cornmeal"))]
-    #[case::multiword_left(
-        "Nilla wafers or graham crackers",
-        "Nilla wafers",
-        Some("or graham crackers")
-    )]
-    // Guards: multi-coordination, prep adjective after "or", trailing stopword.
-    #[case::and_guard(
-        "raw or roasted and salted shelled sunflower seeds",
-        "raw or roasted and salted shelled sunflower seeds",
-        None
-    )]
-    #[case::prep_adj_after_or("basil or chopped parsley", "basil", Some("or chopped parsley"))]
-    #[case::stopword_after_or("salt or pepper to taste", "salt", Some("or pepper to taste"))]
-    #[case::no_or("onion", "onion", None)]
-    // A size-word OR size-word pair is a size range of one ingredient, not a
-    // two-ingredient alternative — leave the name whole.
-    #[case::size_range("medium or large garlic clove", "medium or large garlic clove", None)]
-    // Path B: a trailing DISTRIBUTABLE_HEAD_NOUN distributes onto an open-ended
-    // left (no left-vocab match needed), including a multi-word left.
-    #[case::distribute_stock(
-        "chicken or vegetable stock",
-        "chicken stock",
-        Some("or vegetable stock")
-    )]
-    #[case::distribute_mustard(
-        "grainy or Dijon mustard",
-        "grainy mustard",
-        Some("or Dijon mustard")
-    )]
-    #[case::distribute_pepper("pink or black pepper", "pink pepper", Some("or black pepper"))]
-    #[case::distribute_multiword_left(
-        "Little Gem or Bibb lettuce",
-        "Little Gem lettuce",
-        Some("or Bibb lettuce")
-    )]
-    // Guard: a head noun *not* in the list (oil/spirits) must not distribute —
-    // "butter" is a distinct ingredient, not a kind of oil.
-    #[case::distribute_excludes_oil("butter or olive oil", "butter", Some("or olive oil"))]
-    #[case::distribute_excludes_spirit("amaretto or dark rum", "amaretto", Some("or dark rum"))]
-    // Guard: a single-token right (the head noun itself) never distributes.
-    #[case::distribute_single_token_right("salt or pepper", "salt", Some("or pepper"))]
-    fn test_split_word_alternative(
-        #[case] name: &str,
-        #[case] want_name: &str,
-        #[case] want_alternative: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let (got_name, got_alternative) =
-            alternatives::split_word_alternative(name, &parser.adjectives);
-        assert_eq!(got_name, want_name, "name: {name}");
-        assert_eq!(got_alternative.as_deref(), want_alternative, "name: {name}");
-    }
-
-    /// A comma+or alternatives list whose shared head noun trails the final
-    /// option (stranded by the grammar's first-comma split) recovers the head
-    /// onto the single-token name; lists of complete ingredients are left alone.
-    #[rstest]
-    // Fires: bare options share the trailing head noun "oil".
-    #[case::oil(
-        "canola",
-        Some("vegetable, or melted coconut oil"),
-        "canola oil",
-        Some("or vegetable, or melted coconut oil")
-    )]
-    // Guard: final word isn't a curated shared head → no graft ("salt paprika").
-    #[case::complete_nouns("salt", Some("pepper, or paprika"), "salt", Some("pepper, or paprika"))]
-    #[case::baking_soda(
-        "flour",
-        Some("sugar, or baking soda"),
-        "flour",
-        Some("sugar, or baking soda")
-    )]
-    // Guard: no comma → just a two-way alternative, not a shared-head list.
-    #[case::no_comma("flour", Some("or oil"), "flour", Some("or oil"))]
-    // Guard: name already has a head noun (multi-token) → untouched.
-    #[case::multitoken_name(
-        "olive oil",
-        Some("vegetable, or canola oil"),
-        "olive oil",
-        Some("vegetable, or canola oil")
-    )]
-    fn test_recover_shared_head_from_alternatives(
-        #[case] name: &str,
-        #[case] modifier: Option<&str>,
-        #[case] want_name: &str,
-        #[case] want_modifier: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, modifier);
-        parser.recover_shared_head_from_alternatives(&mut i);
-        assert_eq!(i.name, want_name, "name: {name}");
-        assert_eq!(
-            i.modifier_string().as_deref(),
-            want_modifier,
-            "name: {name}"
-        );
-    }
-
-    /// The IR exposes a typed view of the modifier: extracted adjectives land in
-    /// `prep`, alternatives in `alternatives` — not a single opaque string.
-    #[test]
-    fn test_typed_modifier_view() {
-        let parser = IngredientParser::new();
-
-        let mut i = ing("chopped onion", None);
-        parser.extract_adjectives_from_name(&mut i);
-        assert_eq!(i.prep(), vec!["chopped"]);
-        assert!(i.alternatives().is_empty());
-
-        let mut i = ing("garlic or 1 teaspoon garlic powder", None);
-        parser.extract_alternative_from_name(&mut i);
-        assert_eq!(i.alternatives(), vec!["or 1 teaspoon garlic powder"]);
-        assert!(i.prep().is_empty());
-        // And it still flattens to the same modifier string.
-        assert_eq!(
-            Ingredient::from(i).modifier.as_deref(),
-            Some("or 1 teaspoon garlic powder")
-        );
-    }
-
-    /// Postfix produce units: the trailing count noun becomes the unit and the
-    /// food becomes the name; leading descriptors move to the modifier. Idioms
-    /// (food not on the allowlist) and non-count leads are left untouched.
-    #[test]
-    fn test_extract_postfix_produce_unit() {
-        let parser = IngredientParser::new();
-
-        let mut i = ParsedIngredient {
-            name: "medium garlic clove".into(),
-            amounts: vec![Measure::new("whole", 1.0)],
-            modifier: vec![],
-            optional: false,
-        };
-        parser.extract_postfix_produce_unit(&mut i);
-        assert_eq!(i.name, "garlic");
-        assert_eq!(i.amounts, vec![Measure::new("clove", 1.0)]);
-        assert_eq!(i.modifier_string().as_deref(), Some("medium"));
-
-        // Idiom guard: cinnamon isn't a produce food, so "cinnamon stick" stays.
-        let mut i = ParsedIngredient {
-            name: "cinnamon stick".into(),
-            amounts: vec![Measure::new("whole", 1.0)],
-            modifier: vec![],
-            optional: false,
-        };
-        parser.extract_postfix_produce_unit(&mut i);
-        assert_eq!(i.name, "cinnamon stick");
-        assert_eq!(i.amounts, vec![Measure::new("whole", 1.0)]);
-
-        // A real volume/weight lead (not a plain count) → don't fire.
-        let mut i = ParsedIngredient {
-            name: "garlic clove".into(),
-            amounts: vec![Measure::new("cup", 1.0)],
-            modifier: vec![],
-            optional: false,
-        };
-        parser.extract_postfix_produce_unit(&mut i);
-        assert_eq!(i.name, "garlic clove");
-    }
-
-    /// Size-as-count-unit: a leading size descriptor on an explicit whole count
-    /// becomes the unit ("3 medium carrots" -> `{medium:3}` carrots), with guards
-    /// for ranges, no-count, another-unit, "baby", and the size-range "or".
-    #[test]
-    fn test_extract_size_unit_from_name() {
-        let parser = IngredientParser::new();
-        let fire = |name: &str, amounts: Vec<Measure>| {
-            let mut i = ParsedIngredient {
-                name: name.into(),
-                amounts,
-                modifier: vec![],
-                optional: false,
-            };
-            parser.extract_size_unit_from_name(&mut i);
-            (i.name, i.amounts)
-        };
-
-        // Fires: size becomes the unit, name is the bare produce.
-        let (n, a) = fire("medium carrots", vec![Measure::new("whole", 3.0)]);
-        assert_eq!(
-            (n.as_str(), a),
-            ("carrots", vec![Measure::new("medium", 3.0)])
-        );
-
-        // Multi-word grade canonicalizes; "extra-large" spelling too.
-        let (n, a) = fire("extra large eggs", vec![Measure::new("whole", 2.0)]);
-        assert_eq!(
-            (n.as_str(), a),
-            ("eggs", vec![Measure::new("extra large", 2.0)])
-        );
-        let (n, a) = fire("extra-large eggs", vec![Measure::new("whole", 1.0)]);
-        assert_eq!(
-            (n.as_str(), a),
-            ("eggs", vec![Measure::new("extra large", 1.0)])
-        );
-
-        // Range upper_value is preserved.
-        let (n, a) = fire(
-            "medium onions",
-            vec![Measure::with_range("whole", 1.0, 2.0)],
-        );
-        assert_eq!(
-            (n.as_str(), a),
-            ("onions", vec![Measure::with_range("medium", 1.0, 2.0)])
-        );
-
-        // Guards (name/amounts unchanged):
-        // no explicit whole count → nothing to size.
-        assert_eq!(fire("medium onion", vec![]).0, "medium onion");
-        // another unit already fills the slot.
-        let (n, _) = fire("large onion", vec![Measure::new("cup", 2.0)]);
-        assert_eq!(n, "large onion");
-        // "baby" is a variety, excluded from SIZE_UNIT_WORDS.
-        assert_eq!(
-            fire("baby carrots", vec![Measure::new("whole", 2.0)]).0,
-            "baby carrots"
-        );
-        // a size *range* ("medium or large") is left whole.
-        assert_eq!(
-            fire("medium or large carrots", vec![Measure::new("whole", 1.0)]).0,
-            "medium or large carrots"
-        );
-        // a bare size with no following noun does not fire.
-        assert_eq!(fire("medium", vec![Measure::new("whole", 1.0)]).0, "medium");
-    }
-
-    /// A trailing "for `<gerund>` …" clause (object included) moves to the
-    /// modifier; a plain "<name> for <noun>" is left intact.
-    #[rstest]
-    #[case::gerund(
-        "Extra-virgin olive oil for brushing the bread",
-        "Extra-virgin olive oil",
-        Some("for brushing the bread")
-    )]
-    #[case::non_gerund("flour for bread", "flour for bread", None)]
-    fn test_extract_purpose_gerund(
-        #[case] name: &str,
-        #[case] want_name: &str,
-        #[case] want_modifier: Option<&str>,
-    ) {
-        let parser = IngredientParser::new();
-        let mut i = ing(name, None);
-        parser.extract_purpose_gerund(&mut i);
-        assert_eq!(i.name, want_name);
-        assert_eq!(i.modifier_string().as_deref(), want_modifier);
-    }
-
-    /// The ordered `REFINE_PIPELINE` must be idempotent: running it a second
-    /// time on its own output must change nothing. This is the invariant the
-    /// load-bearing pass order depends on — a pass that isn't a fixpoint (e.g. it
-    /// re-extracts an adjective it already moved, or re-splits an alternative)
-    /// would silently corrupt results when a later edit reorders the list. This
-    /// test fails the moment that happens, naming the offending line.
-    #[rstest]
-    #[case::leading_adjective("1 onion, finely chopped")]
-    #[case::name_adjective("1 cup packed brown sugar, sifted")]
-    #[case::word_alternative("red or white onion")]
-    #[case::shared_head_alternatives("canola, vegetable, or melted coconut oil")]
-    #[case::quantity_alternative("1 clove garlic or 1 teaspoon garlic powder")]
-    #[case::secondary_amount("1 stick butter (8 tablespoons)")]
-    #[case::leading_prep_phrase("grated zest of 1 lemon")]
-    #[case::plain_name("kosher salt")]
-    #[case::postfix_produce("1 medium or large garlic clove, peeled")]
-    #[case::purpose_gerund("Extra-virgin olive oil for brushing the bread")]
-    #[case::fresh_extracted("fresh mint")]
-    #[case::and_guard("Kosher salt and freshly ground black pepper")]
-    fn refine_pipeline_is_idempotent(#[case] line: &str) {
-        let parser = IngredientParser::new();
-        let (_, parsed) = parser.parse_ingredient(line).unwrap();
-
-        let mut once = parsed.clone();
-        parser.refine(&mut once);
-        let mut twice = once.clone();
-        parser.refine(&mut twice);
-
-        assert_eq!(once, twice, "refine is not idempotent for {line:?}");
-    }
-}
+mod tests;

--- a/ingredient-parser/src/parser/refine/alternatives.rs
+++ b/ingredient-parser/src/parser/refine/alternatives.rs
@@ -57,12 +57,16 @@ impl IngredientParser {
         parsed.push_modifier(ModifierPart::Prep(prefix));
     }
 
-    pub(super) fn extract_alternative_from_name(&self, parsed: &mut ParsedIngredient) {
-        let (name, alternative) = extract_alternative(&parsed.name);
+    fn apply_alternative_split(parsed: &mut ParsedIngredient, split: (String, Option<String>)) {
+        let (name, alternative) = split;
         parsed.name = name;
         if let Some(alternative) = alternative {
             parsed.push_modifier(ModifierPart::Alternative(alternative));
         }
+    }
+
+    pub(super) fn extract_alternative_from_name(&self, parsed: &mut ParsedIngredient) {
+        Self::apply_alternative_split(parsed, extract_alternative(&parsed.name));
     }
 
     /// Split a no-quantity "X or Y" alternative left in the name into the
@@ -70,11 +74,10 @@ impl IngredientParser {
     /// [`Self::extract_alternative_from_name`]), so any "or" remaining here is a
     /// plain ingredient/adjective alternative sharing the primary's amount.
     pub(super) fn extract_word_alternative_from_name(&self, parsed: &mut ParsedIngredient) {
-        let (name, alternative) = split_word_alternative(&parsed.name, &self.adjectives);
-        parsed.name = name;
-        if let Some(alternative) = alternative {
-            parsed.push_modifier(ModifierPart::Alternative(alternative));
-        }
+        Self::apply_alternative_split(
+            parsed,
+            split_word_alternative(&parsed.name, &self.adjectives),
+        );
     }
 
     /// Split an inclusive "X and/or Y" coordination out of the name into the
@@ -82,13 +85,7 @@ impl IngredientParser {
     /// phrase survives parsing; this pass then keeps the primary ingredient in
     /// `name` and preserves the author's "and/or" wording in the modifier.
     pub(super) fn extract_and_or_alternative_from_name(&self, parsed: &mut ParsedIngredient) {
-        use regex::Regex;
-        use std::sync::LazyLock;
-
-        static AND_OR_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-            #[allow(clippy::expect_used)]
-            Regex::new(r"(?i)\s+and/or\s+").expect("invalid and/or split regex")
-        });
+        crate::lazy_regex!(AND_OR_PATTERN, r"(?i)\s+and/or\s+");
 
         let Some(m) = AND_OR_PATTERN.find(&parsed.name) else {
             return;
@@ -162,12 +159,9 @@ impl IngredientParser {
 /// - `cleaned_name`: The ingredient name with alternative removed
 /// - `optional_alternative`: The alternative portion to be added to modifier
 fn extract_alternative(name: &str) -> (String, Option<String>) {
-    use regex::Regex;
-    use std::sync::LazyLock;
-
-    static ALTERNATIVE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
+    crate::lazy_regex!(ALTERNATIVE_PATTERN, {
+        use regex::Regex;
         let frac = crate::fraction::VULGAR_FRACTIONS;
-        #[allow(clippy::expect_used)]
         Regex::new(&format!(r"(?i)\s+or\s+(\d+|[{frac}]|a\s+|an\s+)"))
             .expect("invalid alternative pattern regex")
     });
@@ -209,15 +203,9 @@ pub(super) fn split_word_alternative(
     name: &str,
     adjectives: &std::collections::HashSet<String>,
 ) -> (String, Option<String>) {
-    use regex::Regex;
-    use std::sync::LazyLock;
-
     // First word-boundary " or ", case-insensitive. Matching on the original
     // `name` (not a lowercased copy) keeps the byte offsets valid for slicing.
-    static OR_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"(?i)\s+or\s+").expect("invalid or-split regex")
-    });
+    crate::lazy_regex!(OR_PATTERN, r"(?i)\s+or\s+");
 
     let Some(m) = OR_PATTERN.find(name) else {
         return (name.to_string(), None);
@@ -265,14 +253,6 @@ pub(super) fn split_word_alternative(
 
     // Stopwords/prepositions signal `right` is a noun + trailing phrase
     // ("pepper to taste"), not "adjective + shared head" ("white onion").
-    const STOPWORDS: &[&str] = &[
-        "to", "for", "with", "if", "such", "plus", "about", "as", "per", "from", "into", "over",
-        "on", "in", "at", "the", "a", "an", "of",
-    ];
-
-    // Only an *adjective* left can share the right side's head noun ("fresh or
-    // frozen blueberries" -> "fresh blueberries"). A complete-noun left absorbs
-    // nothing ("amaretto or dark rum" stays "amaretto", not "amaretto rum").
     let left_lower = left.to_lowercase();
     let left_is_premodifier = crate::parser::vocab::is_shared_head_modifier(&left_lower)
         || adjectives.contains(&left_lower);
@@ -285,7 +265,7 @@ pub(super) fn split_word_alternative(
         && !adjectives.contains(&right_tokens[0].to_lowercase())
         && !right_tokens
             .iter()
-            .any(|t| STOPWORDS.contains(&t.to_lowercase().as_str()));
+            .any(|t| crate::parser::vocab::MODIFIER_STOPWORDS.contains(&t.to_lowercase().as_str()));
 
     // Path A — a single known-premodifier left shares the right's head noun:
     // "red or white onion" -> "red onion".

--- a/ingredient-parser/src/parser/refine/amounts.rs
+++ b/ingredient-parser/src/parser/refine/amounts.rs
@@ -26,24 +26,11 @@ fn extract_secondary_amounts(
     modifier: &str,
     units: &std::collections::HashSet<String>,
 ) -> (Vec<Measure>, String) {
-    use regex::Regex;
-    use std::sync::LazyLock;
-
-    // An explicit approximation aside, anywhere in the modifier: "(about 2 cups)".
-    static SECONDARY_AMOUNT_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"\((?:from\s+)?(?:about|approximately|roughly|around)\s+([^)]+)\)")
-            .expect("invalid secondary amount regex")
-    });
-    // A bare trailing measure parenthetical: "coarsely chopped (2.1 oz / 60g)" —
-    // a weight/volume equivalence stated for the prepped ingredient. Anchored to
-    // the end and validated below (the inner text must fully parse as a
-    // non-distance measurement), so non-measure asides like "(softened)" or
-    // "(70% cacao)" fall through untouched.
-    static TRAILING_MEASURE_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-        #[allow(clippy::expect_used)]
-        Regex::new(r"\(([^)]+)\)\s*$").expect("invalid trailing-measure regex")
-    });
+    crate::lazy_regex!(
+        SECONDARY_AMOUNT_PATTERN,
+        r"\((?:from\s+)?(?:about|approximately|roughly|around)\s+([^)]+)\)"
+    );
+    crate::lazy_regex!(TRAILING_MEASURE_PATTERN, r"\(([^)]+)\)\s*$");
 
     // The approximation aside wins (it strips the "about" off the amount text);
     // otherwise fall back to a bare trailing measure parenthetical.

--- a/ingredient-parser/src/parser/refine/prep.rs
+++ b/ingredient-parser/src/parser/refine/prep.rs
@@ -2,7 +2,9 @@ use super::*;
 
 impl IngredientParser {
     pub(super) fn extract_adjectives_from_name(&self, parsed: &mut ParsedIngredient) {
-        let mut name_lower = parsed.name.to_lowercase();
+        let Some(mut name_lower) = crate::parser::byte_aligned_lowercase(&parsed.name) else {
+            return;
+        };
         let mut found_adjectives: Vec<&String> = self
             .adjectives
             .iter()
@@ -56,13 +58,6 @@ impl IngredientParser {
             // ("fresh or frozen …"), not the implied default — leave it in the
             // name for the alternative pass to reconstruct ("fresh blueberries").
             if adjective.as_str() == "fresh" && name_lower[end..].starts_with(" or ") {
-                continue;
-            }
-            // `pos`/`end` are byte offsets into the lowercased name. Lowercasing
-            // can change byte lengths for some Unicode (e.g. 'İ' -> "i̇"), so these
-            // offsets may not fall on char boundaries in the original `name`.
-            // Skip rather than panic when slicing `name` would split a char.
-            if !name.is_char_boundary(pos) || !name.is_char_boundary(end) {
                 continue;
             }
 
@@ -216,15 +211,9 @@ impl IngredientParser {
     /// article "the") keep a plain "<name> for <noun>" like "flour for bread"
     /// intact.
     pub(super) fn extract_purpose_gerund(&self, parsed: &mut ParsedIngredient) {
-        use regex::Regex;
-        use std::sync::LazyLock;
-
         // Match the first word-boundary " for " on the original string so the
         // byte offsets stay valid for slicing.
-        static FOR_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-            #[allow(clippy::expect_used)]
-            Regex::new(r"(?i)\s+for\s+").expect("invalid for-clause regex")
-        });
+        crate::lazy_regex!(FOR_PATTERN, r"(?i)\s+for\s+");
 
         // Borrow `parsed.name` for the match/guards; only the two owned result
         // strings are built before the name is reassigned, so no upfront clone.

--- a/ingredient-parser/src/parser/refine/recover.rs
+++ b/ingredient-parser/src/parser/refine/recover.rs
@@ -106,12 +106,6 @@ impl IngredientParser {
                 .to_lowercase();
             wl == "and" || wl == "&"
         };
-        // Stopwords that, as the would-be head noun's first word, mean the modifier
-        // is a prose clause, not "<preps> <head noun>".
-        const STOPWORDS: &[&str] = &[
-            "then", "to", "for", "with", "if", "until", "or", "such", "as", "plus", "about", "per",
-            "from", "into", "over", "on", "in", "at", "the", "a", "an", "of",
-        ];
 
         // Precondition: the name is a pure leading prep chain.
         let name_pure_prep =
@@ -142,7 +136,9 @@ impl IngredientParser {
         let first_lower = first_word
             .trim_matches(|c: char| !c.is_alphanumeric())
             .to_lowercase();
-        if STOPWORDS.contains(&first_lower.as_str()) {
+        // Stopwords that, as the would-be head noun's first word, mean the modifier
+        // is a prose clause, not "<preps> <head noun>".
+        if crate::parser::vocab::MODIFIER_STOPWORDS.contains(&first_lower.as_str()) {
             return;
         }
 

--- a/ingredient-parser/src/parser/refine/tests.rs
+++ b/ingredient-parser/src/parser/refine/tests.rs
@@ -1,0 +1,553 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use super::*;
+use rstest::rstest;
+
+#[test]
+fn refine_pipeline_pass_ids_are_unique() {
+    crate::assert_stage_pipeline!(REFINE_PIPELINE);
+}
+
+fn pass_index(id: PassId) -> usize {
+    REFINE_PIPELINE
+        .iter()
+        .position(|pass| pass.id() == id)
+        .expect("REFINE_PIPELINE missing expected pass")
+}
+
+#[test]
+fn refine_pipeline_order_invariants() {
+    // Prep adjectives must leave the name before any alternative extraction.
+    assert!(
+        pass_index(PassId::ExtractAdjectivesFromName)
+            < pass_index(PassId::ExtractAlternativeFromName),
+        "adjectives before alternatives"
+    );
+    assert!(
+        pass_index(PassId::ExtractAdjectivesFromName)
+            < pass_index(PassId::ExtractWordAlternativeFromName),
+        "adjectives before word alternatives"
+    );
+    assert!(
+        pass_index(PassId::ExtractAdjectivesFromName)
+            < pass_index(PassId::ExtractAndOrAlternativeFromName),
+        "adjectives before and/or alternatives"
+    );
+    // Whitespace collapse sits between adjective peel and alternative passes.
+    assert!(
+        pass_index(PassId::ExtractAdjectivesFromName) < pass_index(PassId::CollapseName),
+        "adjectives before collapse"
+    );
+    assert!(
+        pass_index(PassId::CollapseName) < pass_index(PassId::ExtractAlternativeFromName),
+        "collapse before alternatives"
+    );
+    // Parenthetical amount hoists run after modifier text is fully shaped.
+    assert!(
+        pass_index(PassId::ExtractSecondaryAmountsFromModifier) == REFINE_PIPELINE.len() - 1,
+        "secondary amounts must be last"
+    );
+}
+
+#[rstest]
+// Fully wrapped: outer parens are stripped.
+#[case::simple("(sifted)", Some("sifted"))]
+#[case::with_percent("(70% cacao)", Some("70% cacao"))]
+#[case::inner_trimmed("(  softened  )", Some("softened"))]
+// Not wrapped, or only partially: left untouched.
+#[case::plain("softened", Some("softened"))]
+#[case::open_only("(partial", Some("(partial"))]
+#[case::close_only("partial)", Some("partial)"))]
+// Internal parens must NOT be collapsed (would merge distinct clauses).
+#[case::two_groups("(a) and (b)", Some("(a) and (b)"))]
+#[case::nested("(note (nested))", Some("(note (nested))"))]
+// An empty group collapses away entirely.
+#[case::empty("()", None)]
+fn test_strip_wrapping_parens(#[case] input: &str, #[case] expected: Option<&str>) {
+    assert_eq!(
+        strip_wrapping_parens(Some(input.to_string())),
+        expected.map(str::to_string)
+    );
+}
+
+#[test]
+fn test_strip_wrapping_parens_none() {
+    assert_eq!(strip_wrapping_parens(None), None);
+}
+
+// ------------------------------------------------------------------
+// Per-pass guard tests. These exercise the subtle conditions in each
+// refine pass directly (previously only covered end-to-end by the
+// accuracy corpus), so a regression points at the exact pass.
+// ------------------------------------------------------------------
+
+fn ing(name: &str, modifier: Option<&str>) -> ParsedIngredient {
+    ParsedIngredient {
+        name: name.to_string(),
+        amounts: vec![],
+        modifier: modifier
+            .map(|m| vec![ModifierPart::Raw(m.to_string())])
+            .unwrap_or_default(),
+        optional: false,
+    }
+}
+
+fn ing_with_amounts(name: &str, amounts: Vec<Measure>, modifier: Option<&str>) -> ParsedIngredient {
+    ParsedIngredient {
+        name: name.to_string(),
+        amounts,
+        modifier: modifier
+            .map(|m| vec![ModifierPart::Raw(m.to_string())])
+            .unwrap_or_default(),
+        optional: false,
+    }
+}
+
+/// A name that is exactly a known prep phrase swaps with the modifier; a
+/// descriptive name is left alone (the exact-match guard).
+#[rstest]
+#[case::swaps(
+    "finely chopped",
+    Some("raw pistachios"),
+    "raw pistachios",
+    Some("finely chopped")
+)]
+#[case::no_swap_descriptive(
+    "raw pistachios",
+    Some("finely chopped"),
+    "raw pistachios",
+    Some("finely chopped")
+)]
+#[case::no_swap_no_modifier("chopped", None, "chopped", None)]
+fn test_fix_leading_prep_phrase(
+    #[case] name: &str,
+    #[case] modifier: Option<&str>,
+    #[case] want_name: &str,
+    #[case] want_modifier: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, modifier);
+    parser.fix_leading_prep_phrase(&mut i);
+    assert_eq!(i.name, want_name);
+    assert_eq!(i.modifier_string().as_deref(), want_modifier);
+}
+
+/// "minus <measure> <name>" moves the subtractive clause to the modifier and
+/// restores the real name.
+#[test]
+fn test_fix_leading_minus_clause() {
+    let parser = IngredientParser::new();
+    let mut i = ing("minus 1 tablespoon flour", None);
+    parser.fix_leading_minus_clause(&mut i);
+    assert_eq!(i.name, "flour");
+    assert_eq!(i.modifier_string().as_deref(), Some("minus 1 tablespoon"));
+}
+
+/// Adjectives are pulled from the name into the modifier, but only on word
+/// boundaries (so "well-chopped" is left intact).
+#[rstest]
+#[case::extracts("chopped onion", "onion", Some("chopped"))]
+#[case::boundary_guard("well-chopped onion", "well-chopped onion", None)]
+// Two adjectives in one name exercise the loop's name/name_lower rebuild.
+#[case::two_adjectives("chopped sifted flour", "flour", Some("chopped, sifted"))]
+// An adjective inside an "or" alternative is left for the alternative
+// passes ("chopped" describes parsley, not basil). One before "or" is
+// still extracted.
+#[case::after_or_left_alone("basil or chopped parsley", "basil or chopped parsley", None)]
+#[case::before_or_extracted("chopped basil or parsley", "basil or parsley", Some("chopped"))]
+// " and " guard: a mid-seam adjective belongs to the second conjunct and is
+// left in the name (it's really two ingredients — a parse_multi concern)…
+#[case::and_guard_keeps_conjunct(
+    "Kosher salt and freshly ground black pepper",
+    "Kosher salt and freshly ground black pepper",
+    None
+)]
+// …but a TRAILING phrase after "and" (end-of-string) is still extracted.
+#[case::and_trailing_extracted("Salt and pepper to taste", "Salt and pepper", Some("to taste"))]
+// bare "grated" extracts; "fresh" (implied default) extracts…
+#[case::grated_extracts("grated lemon zest", "lemon zest", Some("grated"))]
+#[case::cubed_extracts("cubed seedless watermelon", "seedless watermelon", Some("cubed"))]
+#[case::fresh_extracts("fresh mint", "mint", Some("fresh"))]
+// …except "fresh or frozen" — a genuine contrast — keeps "fresh" in the name.
+#[case::fresh_or_kept("fresh or frozen blueberries", "fresh or frozen blueberries", None)]
+fn test_extract_adjectives_from_name(
+    #[case] name: &str,
+    #[case] want_name: &str,
+    #[case] want_modifier: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, None);
+    parser.extract_adjectives_from_name(&mut i);
+    assert_eq!(i.name, want_name);
+    assert_eq!(i.modifier_string().as_deref(), want_modifier);
+}
+
+/// A leading "<participle> or <adjective> <noun>" prep alternative moves to
+/// the modifier; a genuine two-ingredient alternative is left alone.
+#[rstest]
+#[case::prep_alt("grated or finely chopped lemon zest", "lemon zest", true)]
+#[case::genuine_alt("basil or chopped parsley", "basil or chopped parsley", false)]
+fn test_extract_leading_prep_alternative(
+    #[case] name: &str,
+    #[case] want_name: &str,
+    #[case] moved: bool,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, None);
+    parser.extract_leading_prep_alternative(&mut i);
+    assert_eq!(i.name, want_name);
+    assert_eq!(i.modifier_string().is_some(), moved, "name: {name}");
+}
+
+#[rstest]
+#[case::plain("thyme and/or rosemary", None, "thyme", Some("and/or rosemary"))]
+#[case::before_raw(
+    "cilantro and/or mint",
+    Some("for serving"),
+    "cilantro",
+    Some("and/or mint, for serving")
+)]
+fn test_extract_and_or_alternative_from_name(
+    #[case] name: &str,
+    #[case] modifier: Option<&str>,
+    #[case] want_name: &str,
+    #[case] want_modifier: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, modifier);
+    parser.extract_and_or_alternative_from_name(&mut i);
+    assert_eq!(i.name, want_name);
+    assert_eq!(i.modifier_string().as_deref(), want_modifier);
+}
+
+#[rstest]
+#[case::recovers_alias(
+    "purple",
+    Some("(red) cabbage (about 1 pound)"),
+    "purple (red) cabbage",
+    Some("(about 1 pound)")
+)]
+#[case::non_alias_amount_left_alone(
+    "cabbage",
+    Some("(about 1 pound)"),
+    "cabbage",
+    Some("(about 1 pound)")
+)]
+fn test_recover_parenthetical_alias_from_modifier(
+    #[case] name: &str,
+    #[case] modifier: Option<&str>,
+    #[case] want_name: &str,
+    #[case] want_modifier: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, modifier);
+    parser.recover_parenthetical_alias_from_modifier(&mut i);
+    assert_eq!(i.name, want_name);
+    assert_eq!(i.modifier_string().as_deref(), want_modifier);
+}
+
+/// "(about N unit)" in the modifier hoists a secondary amount; a distance
+/// aside ("(about 3-inch)") is a shape descriptor and is left in place.
+#[rstest]
+#[case::hoists("chopped (about 2 cups)", 1)]
+#[case::distance_kept("cut into (about 3-inch) strips", 0)]
+// A bare trailing weight parenthetical hoists both measures (oz + g).
+#[case::trailing_weight("coarsely chopped (2.1 oz / 60g)", 2)]
+// A non-measure trailing parenthetical is left in place.
+#[case::non_measure("chopped (softened)", 0)]
+fn test_extract_secondary_amounts_from_modifier(
+    #[case] modifier: &str,
+    #[case] want_amounts: usize,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing("scallions", Some(modifier));
+    parser.extract_secondary_amounts_from_modifier(&mut i);
+    assert_eq!(i.amounts.len(), want_amounts, "modifier: {modifier}");
+}
+
+/// A MID-modifier hoist must not leave a doubled internal space where the
+/// parenthetical was excised (trim only fixes the ends).
+#[test]
+fn test_extract_secondary_amounts_mid_modifier_whitespace() {
+    let parser = IngredientParser::new();
+    let mut i = ing(
+        "parsley",
+        Some("chopped (about 2 cups) plus more for garnish"),
+    );
+    parser.extract_secondary_amounts_from_modifier(&mut i);
+    assert_eq!(i.amounts.len(), 1);
+    assert_eq!(
+        i.modifier_string().as_deref(),
+        Some("chopped plus more for garnish")
+    );
+}
+
+/// A no-quantity "X or Y" alternative is split out of the name, with the head
+/// noun reconstructed onto the primary when the left side is a lone adjective.
+#[rstest]
+// Lone adjective before "or": head noun shared onto the primary.
+#[case::shared_head("red or white onion", "red onion", Some("or white onion"))]
+#[case::shared_multiword_head(
+    "fresh or frozen pitted sweet cherries",
+    "fresh pitted sweet cherries",
+    Some("or frozen pitted sweet cherries")
+)]
+// Distinct nouns (single- or multi-word left): primary = left, no reconstruct.
+#[case::distinct_noun("flour or cornmeal", "flour", Some("or cornmeal"))]
+#[case::multiword_left(
+    "Nilla wafers or graham crackers",
+    "Nilla wafers",
+    Some("or graham crackers")
+)]
+// Guards: multi-coordination, prep adjective after "or", trailing stopword.
+#[case::and_guard(
+    "raw or roasted and salted shelled sunflower seeds",
+    "raw or roasted and salted shelled sunflower seeds",
+    None
+)]
+#[case::prep_adj_after_or("basil or chopped parsley", "basil", Some("or chopped parsley"))]
+#[case::stopword_after_or("salt or pepper to taste", "salt", Some("or pepper to taste"))]
+#[case::no_or("onion", "onion", None)]
+// A size-word OR size-word pair is a size range of one ingredient, not a
+// two-ingredient alternative — leave the name whole.
+#[case::size_range("medium or large garlic clove", "medium or large garlic clove", None)]
+// Path B: a trailing DISTRIBUTABLE_HEAD_NOUN distributes onto an open-ended
+// left (no left-vocab match needed), including a multi-word left.
+#[case::distribute_stock(
+    "chicken or vegetable stock",
+    "chicken stock",
+    Some("or vegetable stock")
+)]
+#[case::distribute_mustard("grainy or Dijon mustard", "grainy mustard", Some("or Dijon mustard"))]
+#[case::distribute_pepper("pink or black pepper", "pink pepper", Some("or black pepper"))]
+#[case::distribute_multiword_left(
+    "Little Gem or Bibb lettuce",
+    "Little Gem lettuce",
+    Some("or Bibb lettuce")
+)]
+// Guard: a head noun *not* in the list (oil/spirits) must not distribute —
+// "butter" is a distinct ingredient, not a kind of oil.
+#[case::distribute_excludes_oil("butter or olive oil", "butter", Some("or olive oil"))]
+#[case::distribute_excludes_spirit("amaretto or dark rum", "amaretto", Some("or dark rum"))]
+// Guard: a single-token right (the head noun itself) never distributes.
+#[case::distribute_single_token_right("salt or pepper", "salt", Some("or pepper"))]
+fn test_split_word_alternative(
+    #[case] name: &str,
+    #[case] want_name: &str,
+    #[case] want_alternative: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let (got_name, got_alternative) =
+        alternatives::split_word_alternative(name, &parser.adjectives);
+    assert_eq!(got_name, want_name, "name: {name}");
+    assert_eq!(got_alternative.as_deref(), want_alternative, "name: {name}");
+}
+
+/// A comma+or alternatives list whose shared head noun trails the final
+/// option (stranded by the grammar's first-comma split) recovers the head
+/// onto the single-token name; lists of complete ingredients are left alone.
+#[rstest]
+// Fires: bare options share the trailing head noun "oil".
+#[case::oil(
+    "canola",
+    Some("vegetable, or melted coconut oil"),
+    "canola oil",
+    Some("or vegetable, or melted coconut oil")
+)]
+// Guard: final word isn't a curated shared head → no graft ("salt paprika").
+#[case::complete_nouns("salt", Some("pepper, or paprika"), "salt", Some("pepper, or paprika"))]
+#[case::baking_soda(
+    "flour",
+    Some("sugar, or baking soda"),
+    "flour",
+    Some("sugar, or baking soda")
+)]
+// Guard: no comma → just a two-way alternative, not a shared-head list.
+#[case::no_comma("flour", Some("or oil"), "flour", Some("or oil"))]
+// Guard: name already has a head noun (multi-token) → untouched.
+#[case::multitoken_name(
+    "olive oil",
+    Some("vegetable, or canola oil"),
+    "olive oil",
+    Some("vegetable, or canola oil")
+)]
+fn test_recover_shared_head_from_alternatives(
+    #[case] name: &str,
+    #[case] modifier: Option<&str>,
+    #[case] want_name: &str,
+    #[case] want_modifier: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, modifier);
+    parser.recover_shared_head_from_alternatives(&mut i);
+    assert_eq!(i.name, want_name, "name: {name}");
+    assert_eq!(
+        i.modifier_string().as_deref(),
+        want_modifier,
+        "name: {name}"
+    );
+}
+
+/// The IR exposes a typed view of the modifier: extracted adjectives land in
+/// `prep`, alternatives in `alternatives` — not a single opaque string.
+#[test]
+fn test_typed_modifier_view() {
+    let parser = IngredientParser::new();
+
+    let mut i = ing("chopped onion", None);
+    parser.extract_adjectives_from_name(&mut i);
+    assert_eq!(i.prep(), vec!["chopped"]);
+    assert!(i.alternatives().is_empty());
+
+    let mut i = ing("garlic or 1 teaspoon garlic powder", None);
+    parser.extract_alternative_from_name(&mut i);
+    assert_eq!(i.alternatives(), vec!["or 1 teaspoon garlic powder"]);
+    assert!(i.prep().is_empty());
+    // And it still flattens to the same modifier string.
+    assert_eq!(
+        Ingredient::from(i).modifier.as_deref(),
+        Some("or 1 teaspoon garlic powder")
+    );
+}
+
+/// Postfix produce units: the trailing count noun becomes the unit and the
+/// food becomes the name; leading descriptors move to the modifier. Idioms
+/// (food not on the allowlist) and non-count leads are left untouched.
+#[test]
+fn test_extract_postfix_produce_unit() {
+    let parser = IngredientParser::new();
+
+    let mut i = ing_with_amounts(
+        "medium garlic clove",
+        vec![Measure::new("whole", 1.0)],
+        None,
+    );
+    parser.extract_postfix_produce_unit(&mut i);
+    assert_eq!(i.name, "garlic");
+    assert_eq!(i.amounts, vec![Measure::new("clove", 1.0)]);
+    assert_eq!(i.modifier_string().as_deref(), Some("medium"));
+
+    // Idiom guard: cinnamon isn't a produce food, so "cinnamon stick" stays.
+    let mut i = ing_with_amounts("cinnamon stick", vec![Measure::new("whole", 1.0)], None);
+    parser.extract_postfix_produce_unit(&mut i);
+    assert_eq!(i.name, "cinnamon stick");
+    assert_eq!(i.amounts, vec![Measure::new("whole", 1.0)]);
+
+    // A real volume/weight lead (not a plain count) → don't fire.
+    let mut i = ing_with_amounts("garlic clove", vec![Measure::new("cup", 1.0)], None);
+    parser.extract_postfix_produce_unit(&mut i);
+    assert_eq!(i.name, "garlic clove");
+}
+
+/// Size-as-count-unit: a leading size descriptor on an explicit whole count
+/// becomes the unit ("3 medium carrots" -> `{medium:3}` carrots), with guards
+/// for ranges, no-count, another-unit, "baby", and the size-range "or".
+#[test]
+fn test_extract_size_unit_from_name() {
+    let parser = IngredientParser::new();
+    let fire = |name: &str, amounts: Vec<Measure>| {
+        let mut i = ing_with_amounts(name, amounts, None);
+        parser.extract_size_unit_from_name(&mut i);
+        (i.name, i.amounts)
+    };
+
+    // Fires: size becomes the unit, name is the bare produce.
+    let (n, a) = fire("medium carrots", vec![Measure::new("whole", 3.0)]);
+    assert_eq!(
+        (n.as_str(), a),
+        ("carrots", vec![Measure::new("medium", 3.0)])
+    );
+
+    // Multi-word grade canonicalizes; "extra-large" spelling too.
+    let (n, a) = fire("extra large eggs", vec![Measure::new("whole", 2.0)]);
+    assert_eq!(
+        (n.as_str(), a),
+        ("eggs", vec![Measure::new("extra large", 2.0)])
+    );
+    let (n, a) = fire("extra-large eggs", vec![Measure::new("whole", 1.0)]);
+    assert_eq!(
+        (n.as_str(), a),
+        ("eggs", vec![Measure::new("extra large", 1.0)])
+    );
+
+    // Range upper_value is preserved.
+    let (n, a) = fire(
+        "medium onions",
+        vec![Measure::with_range("whole", 1.0, 2.0)],
+    );
+    assert_eq!(
+        (n.as_str(), a),
+        ("onions", vec![Measure::with_range("medium", 1.0, 2.0)])
+    );
+
+    // Guards (name/amounts unchanged):
+    // no explicit whole count → nothing to size.
+    assert_eq!(fire("medium onion", vec![]).0, "medium onion");
+    // another unit already fills the slot.
+    let (n, _) = fire("large onion", vec![Measure::new("cup", 2.0)]);
+    assert_eq!(n, "large onion");
+    // "baby" is a variety, excluded from SIZE_UNIT_WORDS.
+    assert_eq!(
+        fire("baby carrots", vec![Measure::new("whole", 2.0)]).0,
+        "baby carrots"
+    );
+    // a size *range* ("medium or large") is left whole.
+    assert_eq!(
+        fire("medium or large carrots", vec![Measure::new("whole", 1.0)]).0,
+        "medium or large carrots"
+    );
+    // a bare size with no following noun does not fire.
+    assert_eq!(fire("medium", vec![Measure::new("whole", 1.0)]).0, "medium");
+}
+
+/// A trailing "for `<gerund>` …" clause (object included) moves to the
+/// modifier; a plain "<name> for <noun>" is left intact.
+#[rstest]
+#[case::gerund(
+    "Extra-virgin olive oil for brushing the bread",
+    "Extra-virgin olive oil",
+    Some("for brushing the bread")
+)]
+#[case::non_gerund("flour for bread", "flour for bread", None)]
+fn test_extract_purpose_gerund(
+    #[case] name: &str,
+    #[case] want_name: &str,
+    #[case] want_modifier: Option<&str>,
+) {
+    let parser = IngredientParser::new();
+    let mut i = ing(name, None);
+    parser.extract_purpose_gerund(&mut i);
+    assert_eq!(i.name, want_name);
+    assert_eq!(i.modifier_string().as_deref(), want_modifier);
+}
+
+/// The ordered `REFINE_PIPELINE` must be idempotent: running it a second
+/// time on its own output must change nothing. This is the invariant the
+/// load-bearing pass order depends on — a pass that isn't a fixpoint (e.g. it
+/// re-extracts an adjective it already moved, or re-splits an alternative)
+/// would silently corrupt results when a later edit reorders the list. This
+/// test fails the moment that happens, naming the offending line.
+#[rstest]
+#[case::leading_adjective("1 onion, finely chopped")]
+#[case::name_adjective("1 cup packed brown sugar, sifted")]
+#[case::word_alternative("red or white onion")]
+#[case::shared_head_alternatives("canola, vegetable, or melted coconut oil")]
+#[case::quantity_alternative("1 clove garlic or 1 teaspoon garlic powder")]
+#[case::secondary_amount("1 stick butter (8 tablespoons)")]
+#[case::leading_prep_phrase("grated zest of 1 lemon")]
+#[case::plain_name("kosher salt")]
+#[case::postfix_produce("1 medium or large garlic clove, peeled")]
+#[case::purpose_gerund("Extra-virgin olive oil for brushing the bread")]
+#[case::fresh_extracted("fresh mint")]
+#[case::and_guard("Kosher salt and freshly ground black pepper")]
+fn refine_pipeline_is_idempotent(#[case] line: &str) {
+    let parser = IngredientParser::new();
+    let (_, parsed) = parser.parse_ingredient(line).unwrap();
+
+    let mut once = parsed.clone();
+    parser.refine(&mut once);
+    let mut twice = once.clone();
+    parser.refine(&mut twice);
+
+    assert_eq!(once, twice, "refine is not idempotent for {line:?}");
+}

--- a/ingredient-parser/src/parser/stage.rs
+++ b/ingredient-parser/src/parser/stage.rs
@@ -1,0 +1,128 @@
+//! Shared stage-pipeline infrastructure for normalize, recognize, and refine.
+//!
+//! [`define_stage_pipeline!`](crate::define_stage_pipeline) generates an Id enum,
+//! Entry struct, and ordered TABLE const from a single row list.
+
+/// Declare a lazy-compiled regex. Pass a string literal pattern, or a block
+/// expression that evaluates to a `regex::Regex` (for patterns built with `format!`).
+#[macro_export]
+macro_rules! lazy_regex {
+    ($name:ident, $pat:literal) => {
+        static $name: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+            #[allow(clippy::expect_used)]
+            regex::Regex::new($pat).expect(concat!("invalid regex: ", $pat))
+        });
+    };
+    ($name:ident, { $($body:tt)* }) => {
+        static $name: std::sync::LazyLock<regex::Regex> = std::sync::LazyLock::new(|| {
+            #[allow(clippy::expect_used)]
+            { $($body)* }
+        });
+    };
+}
+
+/// From one row list, generate Id + as_str + Entry + TABLE. Each row is
+/// `(Variant, "trace_label", run_fn)`. Set `trace: none` or
+/// `trace: pub(crate) TRACE_NAMES` to optionally emit a label slice for tracing.
+#[macro_export]
+macro_rules! define_stage_pipeline {
+    (
+        $(#[$enum_meta:meta])*
+        $id_vis:vis enum $id:ident,
+        $entry_vis:vis struct $entry:ident,
+        $table_vis:vis const $table:ident: &[$entry_ty:ident],
+        type $run_ty:ident = $run_ty_sig:ty,
+        trace: none,
+        $( ( $variant:ident, $label:literal, $run:expr ) ),+ $(,)?
+    ) => {
+        $crate::define_stage_pipeline! {
+            @core
+            $(#[$enum_meta])*
+            $id_vis enum $id,
+            $entry_vis struct $entry,
+            $table_vis const $table: &[$entry_ty],
+            type $run_ty = $run_ty_sig,
+            $( ( $variant, $label, $run ) ),+
+        }
+    };
+    (
+        $(#[$enum_meta:meta])*
+        $id_vis:vis enum $id:ident,
+        $entry_vis:vis struct $entry:ident,
+        $table_vis:vis const $table:ident: &[$entry_ty:ident],
+        type $run_ty:ident = $run_ty_sig:ty,
+        trace: $trace_vis:vis $trace_names:ident,
+        $( ( $variant:ident, $label:literal, $run:expr ) ),+ $(,)?
+    ) => {
+        $crate::define_stage_pipeline! {
+            @core
+            $(#[$enum_meta])*
+            $id_vis enum $id,
+            $entry_vis struct $entry,
+            $table_vis const $table: &[$entry_ty],
+            type $run_ty = $run_ty_sig,
+            $( ( $variant, $label, $run ) ),+
+        }
+        $trace_vis const $trace_names: &[&str] = &[
+            $( $label ),+
+        ];
+    };
+    (
+        @core
+        $(#[$enum_meta:meta])*
+        $id_vis:vis enum $id:ident,
+        $entry_vis:vis struct $entry:ident,
+        $table_vis:vis const $table:ident: &[$entry_ty:ident],
+        type $run_ty:ident = $run_ty_sig:ty,
+        $( ( $variant:ident, $label:literal, $run:expr ) ),+ $(,)?
+    ) => {
+        $(#[$enum_meta])*
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        $id_vis enum $id {
+            $( $variant ),+
+        }
+
+        impl $id {
+            pub(crate) const fn as_str(self) -> &'static str {
+                match self {
+                    $( Self::$variant => $label ),+
+                }
+            }
+        }
+
+        #[derive(Clone, Copy)]
+        $entry_vis struct $entry {
+            id: $id,
+            run: $run_ty,
+        }
+
+        impl $entry {
+            const fn new(id: $id, run: $run_ty) -> Self {
+                Self { id, run }
+            }
+
+            pub(crate) const fn id(self) -> $id {
+                self.id
+            }
+        }
+
+        $table_vis const $table: &[$entry_ty] = &[
+            $( $entry::new($id::$variant, $run) ),+
+        ];
+    };
+}
+
+/// Assert that a stage pipeline table has unique ids and unique, non-empty labels.
+#[macro_export]
+macro_rules! assert_stage_pipeline {
+    ($table:expr) => {{
+        use std::collections::HashSet;
+        let ids: HashSet<_> = $table.iter().map(|entry| entry.id()).collect();
+        assert_eq!(ids.len(), $table.len(), "duplicate stage ids");
+        let labels: HashSet<_> = $table.iter().map(|entry| entry.id().as_str()).collect();
+        assert_eq!(labels.len(), $table.len(), "duplicate stage labels");
+        for entry in $table {
+            assert!(!entry.id().as_str().is_empty(), "empty stage label");
+        }
+    }};
+}

--- a/ingredient-parser/src/parser/vocab.rs
+++ b/ingredient-parser/src/parser/vocab.rs
@@ -5,6 +5,40 @@
 //! is consumed where it was before (seeding the parser's `HashSet`s, or via
 //! `.contains` checks); only the data's home moved.
 
+/// Spelled-out count tokens recognized as leading quantities ("one" … "twelve",
+/// "a"/"an"). Consumed by `normalize::is_count_token`.
+pub(crate) const SPELLED_COUNTS: &[&str] = &[
+    "a", "an", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten",
+    "eleven", "twelve",
+];
+
+/// Spelled-out number words parsed as amounts. Order matches `helpers::text_number`
+/// precedence (longest/most-specific first). Articles "a"/"an" are handled separately
+/// there (they require a trailing space).
+pub(crate) const NUMBER_WORDS: &[(&str, f64)] = &[
+    ("twelve", 12.0),
+    ("eleven", 11.0),
+    ("ten", 10.0),
+    ("nine", 9.0),
+    ("eight", 8.0),
+    ("seven", 7.0),
+    ("six", 6.0),
+    ("five", 5.0),
+    ("four", 4.0),
+    ("three", 3.0),
+    ("two", 2.0),
+    ("one", 1.0),
+    ("dozen", 12.0),
+    ("half", 0.5),
+];
+
+/// Stopwords that signal a modifier clause is prose, not a shared head noun. Union
+/// of the lists used in `refine::recover` and `refine::alternatives`.
+pub(crate) const MODIFIER_STOPWORDS: &[&str] = &[
+    "then", "to", "for", "with", "if", "until", "or", "such", "as", "plus", "about", "per", "from",
+    "into", "over", "on", "in", "at", "the", "a", "an", "of",
+];
+
 /// Preparation adjectives that get extracted from the name into the modifier.
 /// These describe how an ingredient is prepared before use. Multi-word forms
 /// (e.g. "firmly packed") win over their single-word substring ("packed") via

--- a/ingredient-parser/src/trace/mod.rs
+++ b/ingredient-parser/src/trace/mod.rs
@@ -26,6 +26,33 @@ pub use stages::{GrammarOutcome, RecognizerAttempt, StageReport, StageRewrite};
 pub(crate) use collector::{disable_tracing, enable_tracing};
 pub(crate) use collector::{trace_enter, trace_exit_failure, trace_exit_success};
 
+/// Trace a stage step that may or may not change its input (normalize rewrites,
+/// refine passes). Emits a before→after node only when `changed` is true.
+pub(crate) fn trace_on_change(id: &str, before: &str, after: &str, changed: bool) {
+    if changed && is_tracing_enabled() {
+        trace_enter(id, before);
+        trace_exit_success(0, after);
+    }
+}
+
+/// Trace one recognizer attempt. Returns `result` unchanged after optionally
+/// recording success or "no match" in the trace tree.
+pub(crate) fn trace_attempt<T>(
+    id: &str,
+    input: &str,
+    result: Option<T>,
+    format_success: impl FnOnce(&T) -> String,
+) -> Option<T> {
+    if is_tracing_enabled() {
+        trace_enter(id, input);
+        match &result {
+            Some(value) => trace_exit_success(0, &format_success(value)),
+            None => trace_exit_failure("no match"),
+        }
+    }
+    result
+}
+
 use std::fmt;
 use std::time::Instant;
 


### PR DESCRIPTION
## Summary
- Add `parser/stage.rs` with `define_stage_pipeline!`, `assert_stage_pipeline!`, and `lazy_regex!` macros
- Migrate normalize, recognize, and refine to single-source pipeline tables (no behavior change)
- Deduplicate ingredient grammar value/span parsers in `pipeline.rs`
- Centralize vocab (`SPELLED_COUNTS`, `NUMBER_WORDS`, `MODIFIER_STOPWORDS`) and trace helpers (`trace_on_change`, `trace_attempt`)
- Add `byte_aligned_lowercase` for safe Unicode offset alignment in recognize/prep
- Split normalize and refine tests into submodule files; dedupe alternative extract passes

## Test plan
- [x] `cargo nextest run -p ingredient` (968 passed)
- [x] `cargo nextest run` workspace (1140 passed)
- [x] `cargo clippy -p ingredient -- -D warnings`

Made with [Cursor](https://cursor.com)