### PR TITLE
Bridge pinch/dash to teaspoons so tiny-volume lines convert

### DIFF
--- a/ingredient-parser/src/lib.rs
+++ b/ingredient-parser/src/lib.rs
@@ -280,7 +280,7 @@ pub enum Confidence {
 /// [`Ingredient::parse_notes`] and across the wasm boundary as `WParseNotes`.
 ///
 /// It reports **parse fidelity** (did the parse fall back, or leave a digit
-/// unparsed), *not* costability: "a pinch of salt" is a clean parse whose
+/// unparsed), *not* costability: "a handful of parsley" is a clean parse whose
 /// uncostable quantity a consumer derives from the unit, not from here.
 ///
 /// Review-queue consumers should key off the discrete [`fell_back`] /

--- a/ingredient-parser/src/unit/conversion.rs
+++ b/ingredient-parser/src/unit/conversion.rs
@@ -6,7 +6,12 @@
 
 use std::collections::HashMap;
 
-use super::{Unit, kind::MeasureKind, measure::Measure, measure::TSP_TO_ML};
+use super::{
+    Unit,
+    kind::MeasureKind,
+    measure::Measure,
+    measure::{DASH_TO_TSP, PINCH_TO_TSP, TSP_TO_ML},
+};
 use petgraph::Graph;
 use petgraph::graph::NodeIndex;
 use tracing::debug;
@@ -293,6 +298,21 @@ pub struct ConversionStep {
     pub factor: f64,
 }
 
+/// A tiny volumetric unit's size in teaspoons, if `unit` is one.
+///
+/// `unit` must already be normalized (lowercase + singular), which is how every
+/// caller has it — so `"Pinches"` arrives here as `Other("pinch")`.
+fn tiny_volume_in_tsp(unit: &Unit) -> Option<f64> {
+    match unit {
+        Unit::Other(s) => match s.as_str() {
+            "pinch" => Some(PINCH_TO_TSP),
+            "dash" => Some(DASH_TO_TSP),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Convert a measure to a target kind using a pre-built conversion graph.
 ///
 /// This uses the A* algorithm to find the shortest path in the conversion graph
@@ -346,8 +366,38 @@ pub fn convert_measure_with_graph_explained(
     // nutrient works. The source side was already singularized via
     // `measure.normalize()`, but normalizing it through the same function keeps
     // the two endpoints symmetric and order-independent.
-    let unit_a = input.unit().normalize();
+    let mut input = input;
+    let mut unit_a = input.unit().normalize();
     let unit_b = target.unit().normalize();
+
+    // A pinch or dash is a fixed volumetric convention (see DASH_TO_TSP /
+    // PINCH_TO_TSP), not a density — "1 pinch = 1/16 tsp" holds for salt, cayenne,
+    // and everything else alike. Like the oz→g identity below, that makes it a
+    // fact the engine owns rather than something a mapping has to supply, so
+    // rescale into teaspoons and enter the graph at the tsp node. Doing it here
+    // instead of seeding `pinch`/`dash` nodes in `make_graph` keeps them out of
+    // every volume graph: `make_graph` never sees the source measure, so it would
+    // have to add them unconditionally, polluting the graph viz and island
+    // detection with nodes no mapping mentions.
+    //
+    // An explicit `pinch` node wins — if the caller mapped "1 pinch = 0.4 g" for
+    // this product, that measured value beats the convention.
+    let mut steps: Vec<ConversionStep> = Vec::new();
+    if let Some(tsp) = tiny_volume_in_tsp(&unit_a)
+        && !graph.node_indices().any(|i| graph[i] == unit_a)
+    {
+        steps.push(ConversionStep {
+            from_unit: unit_a,
+            to_unit: Unit::Teaspoon,
+            factor: tsp,
+        });
+        input = Measure::new_with_upper(
+            Unit::Teaspoon,
+            input.value() * tsp,
+            input.upper_value().map(|u| u * tsp),
+        );
+        unit_a = Unit::Teaspoon;
+    }
 
     // Identity: once normalized, the measure may already sit in the target kind's
     // base unit (every mass unit normalizes to grams, and Weight targets grams).
@@ -364,7 +414,9 @@ pub fn convert_measure_with_graph_explained(
         let lo = input.value().round();
         let hi = input.upper_value().map(f64::round).filter(|&u| u > lo);
         let resolved = Measure::new_with_upper(unit_b, lo, hi);
-        return Some((resolved.denormalize(), Vec::new()));
+        // `steps` is empty unless a pinch/dash rescale landed us on the target
+        // node, in which case that one synthetic hop IS the whole path.
+        return Some((resolved.denormalize(), steps));
     }
 
     let n_a = graph.node_indices().find(|i| graph[*i] == unit_a)?;
@@ -386,7 +438,7 @@ pub fn convert_measure_with_graph_explained(
     };
     let mut factor_lo: f64 = 1.0;
     let mut factor_hi: f64 = 1.0;
-    let mut steps = Vec::with_capacity(path.len().saturating_sub(1));
+    steps.reserve(path.len().saturating_sub(1));
     for x in 0..path.len() - 1 {
         let (n_from, n_to) = (*path.get(x)?, *path.get(x + 1)?);
         let edge = graph.find_edge(n_from, n_to)?;
@@ -705,12 +757,126 @@ mod tests {
 
     #[test]
     fn test_convert_measure_no_source_node() {
-        let measure = Measure::new("pinch", 1.0);
+        // A genuinely-unknown unit — not a pinch/dash, which the engine bridges
+        // into teaspoons on its own (see `pinch_and_dash_bridge_to_tsp`).
+        let measure = Measure::new("clove", 1.0);
         let mappings = vec![(Measure::new("cup", 1.0), Measure::new("g", 120.0))];
 
         let result = convert_measure_via_mappings(&measure, MeasureKind::Weight, &mappings);
 
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn pinch_and_dash_bridge_to_tsp() {
+        // A pinch/dash is a fixed fraction of a teaspoon, so a product that has
+        // any volume→weight density resolves them with no pinch-specific mapping.
+        // 1 cup = 120 g ⇒ 1 tsp = 2.5 g ⇒ 1 pinch (1/16 tsp) = 0.15625 g → 0 g
+        // rounded, so use a denser mapping to keep the assertion off the rounding
+        // floor: 1 cup = 480 g ⇒ 1 tsp = 10 g.
+        let mappings = vec![(Measure::new("cup", 1.0), Measure::new("g", 480.0))];
+
+        // 1 pinch = 1/16 tsp = 0.625 g → 1 g.
+        let pinch = convert_measure_via_mappings(
+            &Measure::new("pinch", 1.0),
+            MeasureKind::Weight,
+            &mappings,
+        );
+        assert_eq!(pinch.map(|m| m.value()), Some(1.0));
+
+        // 16 pinches = 1 tsp = 10 g exactly.
+        let pinches = convert_measure_via_mappings(
+            &Measure::new("pinches", 16.0),
+            MeasureKind::Weight,
+            &mappings,
+        );
+        assert_eq!(pinches.map(|m| m.value()), Some(10.0));
+
+        // A dash is twice a pinch: 8 dashes = 1 tsp = 10 g.
+        let dashes = convert_measure_via_mappings(
+            &Measure::new("dashes", 8.0),
+            MeasureKind::Weight,
+            &mappings,
+        );
+        assert_eq!(dashes.map(|m| m.value()), Some(10.0));
+    }
+
+    #[test]
+    fn pinch_bridge_shows_in_the_explain_path() {
+        // The synthetic hop must appear in the explained steps, so a costing
+        // explanation reads "pinch —×0.0625→ tsp —×10→ g" rather than starting
+        // mid-path at teaspoons.
+        let graph = make_graph(&[(Measure::new("cup", 1.0), Measure::new("g", 480.0))]);
+        let (_, steps) = convert_measure_with_graph_explained(
+            &Measure::new("pinch", 1.0),
+            MeasureKind::Weight,
+            &graph,
+        )
+        .unwrap();
+
+        assert_eq!(
+            steps.first().map(|s| s.from_unit.clone()),
+            Some(pinch_unit())
+        );
+        assert_eq!(
+            steps.first().map(|s| s.to_unit.clone()),
+            Some(Unit::Teaspoon)
+        );
+        assert_eq!(steps.first().map(|s| s.factor), Some(1.0 / 16.0));
+        assert_eq!(steps.last().map(|s| s.to_unit.clone()), Some(Unit::Gram));
+    }
+
+    #[test]
+    fn explicit_pinch_mapping_beats_the_convention() {
+        // "1 pinch = 5 g" for this product is a measurement; the 1/16-tsp
+        // convention is a default. The measurement wins, and no synthetic hop is
+        // emitted.
+        let graph = make_graph(&[
+            (Measure::new("cup", 1.0), Measure::new("g", 480.0)),
+            (Measure::new("pinch", 1.0), Measure::new("g", 5.0)),
+        ]);
+        let (converted, steps) = convert_measure_with_graph_explained(
+            &Measure::new("pinch", 2.0),
+            MeasureKind::Weight,
+            &graph,
+        )
+        .unwrap();
+
+        assert_eq!(converted.value(), 10.0);
+        assert_eq!(steps.len(), 1);
+        assert_eq!(
+            steps.first().map(|s| s.from_unit.clone()),
+            Some(pinch_unit())
+        );
+    }
+
+    #[test]
+    fn pinch_converts_to_volume_and_carries_a_range() {
+        let mappings = vec![(Measure::new("cup", 1.0), Measure::new("g", 480.0))];
+
+        // Volume targets ml, reached via the seeded tsp↔ml bridge:
+        // 16 pinches = 1 tsp = 4.92892 ml → 5 ml.
+        let ml = convert_measure_via_mappings(
+            &Measure::new("pinch", 16.0),
+            MeasureKind::Volume,
+            &mappings,
+        );
+        assert_eq!(ml.map(|m| m.value()), Some(5.0));
+
+        // A ranged amount ("1–2 pinches") scales both bounds.
+        let ranged = convert_measure_via_mappings(
+            &Measure::with_range("pinch", 16.0, 32.0),
+            MeasureKind::Weight,
+            &mappings,
+        );
+        let ranged = ranged.unwrap();
+        assert_eq!(ranged.value(), 10.0);
+        assert_eq!(ranged.upper_value(), Some(20.0));
+    }
+
+    /// The normalized graph unit for a pinch, spelled once.
+    fn pinch_unit() -> Unit {
+        Unit::Other("pinch".to_string())
     }
 
     #[test]

--- a/ingredient-parser/src/unit/measure.rs
+++ b/ingredient-parser/src/unit/measure.rs
@@ -264,6 +264,15 @@ const TSP_TO_FL_OZ: f64 = TSP_TO_TBSP * 2.0;
 // 1 US tsp = 4.92892 ml (keeps cup = 48 tsp = 236.59 ml consistent). Seeded into the
 // conversion graph so US and metric volumes interconvert; see conversion.rs make_graph.
 pub(crate) const TSP_TO_ML: f64 = 4.92892;
+// The tiny volumetric kitchen units, in teaspoons. Like tsp↔ml these are fixed
+// conventions, not densities: the standard US mini-measuring-spoon set defines a
+// halving ladder where each unit is half the one above it (dash = ½ tsp/4,
+// pinch = ½ dash). That internal consistency is why a pinch is 1/16 tsp here and
+// not the 1/8 sometimes quoted — 1/8 tsp is the *dash*. Applied in
+// conversion.rs's convert path, not seeded as graph nodes; see
+// `tiny_volume_in_tsp`.
+pub(crate) const DASH_TO_TSP: f64 = 1.0 / 8.0;
+pub(crate) const PINCH_TO_TSP: f64 = 1.0 / 16.0;
 const G_TO_K: f64 = 1000.0;
 const CUP_TO_QUART: f64 = 4.0;
 const QUART_TO_GALLON: f64 = 4.0;


### PR DESCRIPTION
## Problem

A pinch or dash had no route into the volume family, so a recipe line measured in pinches could not reach `Weight`/`Calories`/`Money` at all — it errored with "Error converting to weight" and silently dropped out of recipe totals.

Found on cubby's "Gougères", where both `Generous pinch of kosher salt` and `Pinch of cayenne pepper` failed while `½ teaspoon ground nutmeg` on the same recipe converted fine.

## Ratios

A pinch is a fixed volumetric convention, not a density — "1 pinch = 1/16 tsp" holds for salt, cayenne, and everything else alike. The standard US mini-measuring-spoon set is a halving ladder:

| unit | tsp |
| --- | --- |
| dash | 1/8 |
| pinch | 1/16 |

**1/16, not the sometimes-quoted 1/8, for a pinch** — 1/8 tsp is the *dash*, and the halving ladder is what makes the set internally consistent.

`smidgen` (1/32 tsp) deliberately left out: rare enough in real recipes that it isn't worth a third entry until something actually emits it.

## Where it lives, and why not `make_graph`

Handled in `convert_measure_with_graph_explained`, beside the existing oz→g identity shortcut already documented there as "a fixed, density-independent fact … resolved directly instead of requiring both units to appear in the mapping graph": rescale the source measure into teaspoons and enter the graph at the tsp node.

The obvious alternative is to seed `pinch`/`dash` nodes in `make_graph`, next to the tsp↔ml bridge. That's worse: `make_graph` never sees the source measure, so unlike the tsp↔ml bridge (which can gate on a volume unit already being present) it would have to add these nodes **unconditionally** to every graph containing a volume unit — polluting `print_graph`'s viz and `find_connected_components`' island detection with nodes no mapping mentions. The convert path knows the source unit, so the bridge costs nothing when no pinch is involved.

Two details:

- **An explicit `pinch` node wins over the convention**, so a product that genuinely measured "1 pinch = 0.4 g" keeps its own value.
- **The synthetic hop is emitted as a `ConversionStep`**, so an explained conversion reads `pinch —×0.0625→ tsp → g` rather than starting mid-path at teaspoons.

## Tests

Four new tests in `conversion.rs` covering the bridge, plurals (`pinches`/`dashes`), the explain path, explicit-mapping precedence, the `Volume` target via the tsp↔ml bridge, and ranged amounts.

`test_convert_measure_no_source_node` used `"pinch"` as its unreachable-unit example and now uses `"clove"` — the old case is exactly what this PR fixes.

Full suite green; `cargo fmt --check` and clippy clean.

## Verified against real data

Run against cubby's actual stored mappings for Diamond Crystal kosher salt (`1 tsp = 2.8 g`):

```
1 pinch salt    -> 0 g     (was: no conversion)
4 pinch salt    -> 1 g
16 pinch salt   -> 3 g
0.5 tsp salt    -> 1 g     (for scale)
1 pinch cayenne -> None    (no mappings stored for that ingredient at all)
```

Two honest caveats for downstream consumers, neither addressed here:

1. A single pinch of salt is 0.175 g, and conversion results are rounded to whole grams, so the line stops erroring but still contributes ~0. That integer rounding is pre-existing and applies to every conversion (note `0.5 tsp` → 1 g, from 1.4 g); changing it has a wide blast radius.
2. Cayenne still can't convert because that ingredient has no density mapping at all. Not a pinch problem.