### PR TITLE
Hold the hot-path instruments at trace level with skip_all

### DIFF
--- a/ingredient-parser/src/lib.rs
+++ b/ingredient-parser/src/lib.rs
@@ -542,7 +542,7 @@ impl IngredientParser {
     ///    vec![Measure::new("grams",120.0),Measure::new("cup", 1.0),Measure::new("whole", 1.0)]
     ///  );
     /// ```
-    #[tracing::instrument(name = "parse_amount")]
+    #[tracing::instrument(name = "parse_amount", level = "trace", skip_all)]
     pub fn parse_amount(&self, input: &str) -> IngredientResult<Vec<Measure>> {
         let mp = MeasurementParser::new(&self.units, MeasurementMode::IngredientList);
         match mp.parse_measurement_list(input) {

--- a/ingredient-parser/src/parser/measurement/mod.rs
+++ b/ingredient-parser/src/parser/measurement/mod.rs
@@ -111,7 +111,7 @@ impl<'a> MeasurementParser<'a> {
     /// - "120 grams / 1 cup"
     /// - "150 grams | 1 cup" (Bouchon format: metric | volume)
     /// - "1 tsp, 2 tbsp"
-    #[tracing::instrument(name = "many_amount", skip(self))]
+    #[tracing::instrument(name = "many_amount", level = "trace", skip_all)]
     pub fn parse_measurement_list<'b>(&self, input: &'b str) -> Res<&'b str, Vec<Measure>> {
         // Define the separators between measurements
         let amount_separators = alt((

--- a/ingredient-parser/src/parser/pipeline.rs
+++ b/ingredient-parser/src/parser/pipeline.rs
@@ -174,7 +174,7 @@ impl IngredientParser {
     /// This method only captures the raw grammar shape. Cleanup such as adjective
     /// extraction, alternative extraction, and secondary amount extraction happens
     /// in the higher-level ingredient pipeline.
-    #[tracing::instrument(name = "parse_ingredient")]
+    #[tracing::instrument(name = "parse_ingredient", level = "trace", skip_all)]
     pub(crate) fn parse_ingredient<'a>(&self, input: &'a str) -> Res<&'a str, ParsedIngredient> {
         let mp = MeasurementParser::new(&self.units, MeasurementMode::IngredientList);
 

--- a/ingredient-parser/src/rich_text.rs
+++ b/ingredient-parser/src/rich_text.rs
@@ -348,7 +348,7 @@ impl RichParser {
         }
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn parse(&self, input: &str) -> Result<Rich, RichParseError> {
         let units = self.ip.units();
         match context(


### PR DESCRIPTION
## What

Four `#[tracing::instrument]`s on per-call parser methods sat at the **default INFO level**, and three of them Debug-format `&self` — the whole `IngredientParser`, unit table included — on every invocation.

| file | before |
|---|---|
| `lib.rs:545` | `instrument(name = "parse_amount")` |
| `rich_text.rs:351` | `instrument` |
| `parser/pipeline.rs:177` | `instrument(name = "parse_ingredient")` |
| `parser/measurement/mod.rs:114` | `instrument(name = "many_amount", skip(self))` |

All four now carry `level = "trace", skip_all`, matching `unit/conversion.rs:353` which was fixed this way already.

## Why it matters more than it looks

This is the exact shape that took the downstream consumer (cubby) down once. `recipebridge` runs in a long-lived, **reused** workerd isolate, so a global subscriber at INFO plus a per-call instrumented fn accumulates spans whose CPU cost **grows per call** until it trips the worker's `cpu_ms` limit.

It presented as a *slow database write* — workerd's clock is frozen during synchronous CPU, so the time was silently charged to the next awaited I/O. That misdiagnosis is what made it expensive.

Downstream currently pins the subscriber to WARN on workerd, but that guard rests on a `navigator.userAgent` probe: a single point of failure that re-arms all four the moment detection is inconclusive. Defence in depth belongs here, at the instrument.

## Why `skip_all` rather than `skip(self)`

The input strings are recipe text and don't belong in span fields either. And at `trace` level the spans aren't **constructed at all** under a WARN/INFO subscriber — the cost is nil rather than merely smaller.

## Testing

`cargo fmt --check`, `clippy -D warnings`, and `cargo test -p ingredient` (801 + 115 + 9 + 4 + 1 passing) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)