### PR TITLE
Carry recipe times as minutes alongside the printed strings

### DIFF
--- a/ingredient-wasm/src/lib.rs
+++ b/ingredient-wasm/src/lib.rs
@@ -207,7 +207,9 @@ impl WUnitMappings {
     }
 }
 
-/// Prep/cook/total times (mirrors `RecipeTimes`). Into-only.
+/// Prep/cook/total times (mirrors `RecipeTimes`). Into-only. Each time crosses
+/// as both the display string and, where it could be parsed, a minute count for
+/// sorting — a present string does not imply a present count.
 #[derive(Tsify, Serialize)]
 pub struct WRecipeTimes {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -218,6 +220,14 @@ pub struct WRecipeTimes {
     pub prep: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cook: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_minutes: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_minutes: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prep_minutes: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cook_minutes: Option<u32>,
 }
 
 impl From<RecipeTimes> for WRecipeTimes {
@@ -227,6 +237,10 @@ impl From<RecipeTimes> for WRecipeTimes {
             total: t.total,
             prep: t.prep,
             cook: t.cook,
+            active_minutes: t.active_minutes,
+            total_minutes: t.total_minutes,
+            prep_minutes: t.prep_minutes,
+            cook_minutes: t.cook_minutes,
         }
     }
 }

--- a/recipe-epub/src/extractor.rs
+++ b/recipe-epub/src/extractor.rs
@@ -15,6 +15,7 @@ use crate::{Chunk, EpubError};
 // crate and is re-exported here (and from the crate root) so existing
 // `recipe_epub::RecipeMeta` paths are unchanged.
 pub use recipe_types::RecipeMeta;
+use recipe_types::RecipeTimes;
 
 /// Deserialize a `Vec<T>` from malformed LLM tool output. Tolerates an explicit
 /// `null` (→ empty) and a JSON-string-encoded array — the model occasionally
@@ -135,11 +136,113 @@ pub fn build_chunk_request(chunk: &Chunk) -> ChunkRequest {
     }
 }
 
+/// Parse a freeform printed time ("30 minutes", "1 hr 15 min") into whole
+/// minutes. Unlike the scraper's ISO-8601 input this is prose a model copied off
+/// a cookbook page, so it is read strictly: the whole string must be hour and
+/// minute counts (an optional leading approximator aside), or it isn't a number
+/// we're willing to sort by. A range ("30 to 40 minutes"), a fraction ("1 1/2
+/// hours"), a qualifier ("30 minutes, plus chilling") and a bare word
+/// ("overnight") all yield `None` — the display string still carries them, and a
+/// wrong number is worse than no number.
+fn parse_freeform_duration(input: &str) -> Option<u32> {
+    let lowered = input.trim().to_ascii_lowercase();
+    let mut rest = lowered.as_str();
+    // "About 30 minutes" states the same duration as "30 minutes"; the hedge
+    // doesn't make the count ambiguous, so strip one and read on.
+    for approx in [
+        "about ",
+        "approximately ",
+        "approx. ",
+        "approx ",
+        "around ",
+        "roughly ",
+        "~",
+    ] {
+        if let Some(stripped) = rest.strip_prefix(approx) {
+            rest = stripped.trim_start();
+            break;
+        }
+    }
+
+    let mut total: u32 = 0;
+    let mut saw_component = false;
+    let mut chars = rest.chars().peekable();
+    while let Some(&c) = chars.peek() {
+        if c == ' ' {
+            chars.next();
+            continue;
+        }
+        if !c.is_ascii_digit() {
+            // Anything that isn't a count is prose we can't read confidently.
+            return None;
+        }
+        let mut num = String::new();
+        while let Some(&d) = chars.peek() {
+            if d.is_ascii_digit() {
+                num.push(d);
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        while chars.peek() == Some(&' ') {
+            chars.next();
+        }
+        let mut unit = String::new();
+        while let Some(&u) = chars.peek() {
+            if u.is_ascii_alphabetic() {
+                unit.push(u);
+                chars.next();
+            } else {
+                break;
+            }
+        }
+        // An abbreviation may be written with a period ("1 hr. 15 min.").
+        if chars.peek() == Some(&'.') {
+            chars.next();
+        }
+        let per_unit = match unit.as_str() {
+            "h" | "hr" | "hrs" | "hour" | "hours" => 60,
+            "m" | "min" | "mins" | "minute" | "minutes" => 1,
+            // A number with no unit, or a unit we don't measure recipe times in.
+            _ => return None,
+        };
+        total = total.checked_add(num.parse::<u32>().ok()?.checked_mul(per_unit)?)?;
+        saw_component = true;
+    }
+
+    (saw_component && total > 0).then_some(total)
+}
+
+/// Derive each `*_minutes` count from the matching display string the model
+/// emitted. Only fills a count that is absent, so a model that ever starts
+/// emitting the numbers itself wins over this fallback.
+fn fill_time_minutes(times: &mut RecipeTimes) {
+    let pairs: [(&Option<String>, &mut Option<u32>); 4] = [
+        (&times.active, &mut times.active_minutes),
+        (&times.total, &mut times.total_minutes),
+        (&times.prep, &mut times.prep_minutes),
+        (&times.cook, &mut times.cook_minutes),
+    ];
+    for (text, minutes) in pairs {
+        if minutes.is_none() {
+            *minutes = text.as_deref().and_then(parse_freeform_duration);
+        }
+    }
+}
+
 /// Parse the forced tool's `input` object (`{ recipes: [ExtractedRecipe, …] }`)
 /// into recipes. The single place LLM output is decoded — shared by the native
-/// backends and the wasm `assemble_recipes` path.
+/// backends and the wasm `assemble_recipes` path — and therefore the single
+/// place the freeform printed times are turned into sortable minute counts.
 pub fn parse_recipes_payload(input: serde_json::Value) -> Result<Vec<ExtractedRecipe>, EpubError> {
-    Ok(serde_json::from_value::<RecipesPayload>(input)?.recipes)
+    let mut recipes = serde_json::from_value::<RecipesPayload>(input)?.recipes;
+    for recipe in &mut recipes {
+        if let Some(times) = recipe.meta.times.as_mut() {
+            fill_time_minutes(times);
+        }
+    }
+    Ok(recipes)
 }
 
 /// One extra attempt after the first, so one model gets at most `1 + PARSE_RETRIES`
@@ -396,7 +499,59 @@ mod tests {
     #![allow(clippy::unwrap_used)]
     use serde_json::json;
 
-    use super::parse_recipes_payload;
+    use super::{parse_freeform_duration, parse_recipes_payload};
+    use rstest::rstest;
+
+    // ============================================================================
+    // parse_freeform_duration() Tests
+    // ============================================================================
+
+    #[rstest]
+    #[case::minutes("30 minutes", Some(30))]
+    #[case::min_abbrev("45 min", Some(45))]
+    #[case::one_minute("1 minute", Some(1))]
+    #[case::hours("2 hours", Some(120))]
+    #[case::hour_abbrev("1 hr", Some(60))]
+    #[case::hour_and_min("1 hr 15 min", Some(75))]
+    #[case::hour_and_minutes("1 hour 30 minutes", Some(90))]
+    #[case::abbrev_with_periods("1 hr. 15 min.", Some(75))]
+    #[case::no_space("30m", Some(30))]
+    #[case::mixed_case("1 Hour 5 Minutes", Some(65))]
+    // A hedge doesn't change the count.
+    #[case::about("about 30 minutes", Some(30))]
+    #[case::tilde("~45 min", Some(45))]
+    // Ambiguous or unreadable — the display string keeps these, the count doesn't.
+    #[case::range("30 to 40 minutes", None)]
+    #[case::hyphen_range("30-40 minutes", None)]
+    #[case::fraction("1 1/2 hours", None)]
+    #[case::qualified("30 minutes, plus chilling", None)]
+    #[case::word_only("overnight", None)]
+    #[case::no_unit("30", None)]
+    #[case::unknown_unit("2 days", None)]
+    #[case::zero("0 minutes", None)]
+    #[case::empty("", None)]
+    fn test_parse_freeform_duration(#[case] input: &str, #[case] expected: Option<u32>) {
+        assert_eq!(parse_freeform_duration(input), expected);
+    }
+
+    #[test]
+    fn payload_fills_time_minutes_from_prose() {
+        let v = json!({ "recipes": [
+            { "title": "X",
+              "sections": [],
+              "times": { "prep": "20 minutes", "cook": "1 hr 30 min", "total": "overnight" } }
+        ]});
+        let r = parse_recipes_payload(v).unwrap();
+        let times = r[0].meta.times.clone().unwrap();
+        assert_eq!(times.prep_minutes, Some(20));
+        assert_eq!(times.cook_minutes, Some(90));
+        // Unreadable prose keeps its display string but gets no count.
+        assert_eq!(times.total.as_deref(), Some("overnight"));
+        assert_eq!(times.total_minutes, None);
+        // A time the model never emitted stays absent on both halves.
+        assert_eq!(times.active, None);
+        assert_eq!(times.active_minutes, None);
+    }
 
     // Regression: real `claude-haiku-4-5` output on Tartine Book No. 3 produced
     // four malformed chunks that each `?`-aborted the cookbook import. The lenient

--- a/recipe-scraper/src/ld_json.rs
+++ b/recipe-scraper/src/ld_json.rs
@@ -13,19 +13,20 @@ fn is_notes_heading(name: &str) -> bool {
     )
 }
 
-/// Humanize an ISO-8601 duration (e.g. `PT1H30M` -> "1 hour 30 minutes",
-/// `PT35M` -> "35 minutes", `P0DT1H30M` -> "1 hour 30 minutes"). Returns `None`
-/// for anything that isn't a `P…` duration with at least one component. A date
-/// part may carry a day count (folded into hours — WP Recipe Maker emits
-/// `P0DT0H30M`); only hours/minutes are surfaced (seconds are dropped — recipe
-/// times never need them).
-fn humanize_iso8601_duration(input: &str) -> Option<String> {
+/// Parse an ISO-8601 duration (e.g. `PT1H30M`, `PT35M`, `P0DT1H30M`) into whole
+/// minutes. Returns `None` for anything that isn't a `P…` duration with at least
+/// one component, and for a duration that comes to zero minutes (`PT0M`,
+/// `PT45S`) — a recipe time of nothing is no time at all. A date part may carry
+/// a day count (folded into minutes — WP Recipe Maker emits `P0DT0H30M`); only
+/// hours/minutes are surfaced (seconds are dropped — recipe times never need
+/// them). Anything so large it overflows the minute count is adversarial rather
+/// than a recipe time, and is rejected instead of wrapping or panicking.
+fn parse_iso8601_duration(input: &str) -> Option<u32> {
     let rest = input.trim().strip_prefix('P')?;
     let (date_part, time_part) = match rest.split_once('T') {
         Some((d, t)) => (d, t),
         None => (rest, ""),
     };
-    let mut hours: u64 = 0;
     let mut minutes: u64 = 0;
     let mut num = String::new();
     let mut saw_component = false;
@@ -35,19 +36,19 @@ fn humanize_iso8601_duration(input: &str) -> Option<String> {
         let days: u64 = date_part.strip_suffix('D')?.parse().ok()?;
         // Adversarial HTML can carry an absurd day count; saturate-then-reject via
         // checked arithmetic rather than overflow-panic (debug) or wrap (release).
-        hours = hours.checked_add(days.checked_mul(24)?)?;
+        minutes = minutes.checked_add(days.checked_mul(24 * 60)?)?;
         saw_component = true;
     }
     for c in time_part.chars() {
         match c {
             '0'..='9' => num.push(c),
             'H' => {
-                hours += num.parse::<u64>().ok()?;
+                minutes = minutes.checked_add(num.parse::<u64>().ok()?.checked_mul(60)?)?;
                 num.clear();
                 saw_component = true;
             }
             'M' => {
-                minutes = num.parse().ok()?;
+                minutes = minutes.checked_add(num.parse::<u64>().ok()?)?;
                 num.clear();
                 saw_component = true;
             }
@@ -63,7 +64,14 @@ fn humanize_iso8601_duration(input: &str) -> Option<String> {
     if !num.is_empty() || !saw_component {
         return None;
     }
+    let minutes = u32::try_from(minutes).ok()?;
+    (minutes > 0).then_some(minutes)
+}
 
+/// Render whole minutes as prose ("1 hour 30 minutes", "35 minutes"). Only ever
+/// called with a non-zero count, so it always produces at least one part.
+fn humanize_minutes(total: u32) -> String {
+    let (hours, minutes) = (total / 60, total % 60);
     let mut parts = Vec::new();
     if hours > 0 {
         parts.push(format!("{hours} hour{}", if hours == 1 { "" } else { "s" }));
@@ -74,11 +82,16 @@ fn humanize_iso8601_duration(input: &str) -> Option<String> {
             if minutes == 1 { "" } else { "s" }
         ));
     }
-    if parts.is_empty() {
-        None
-    } else {
-        Some(parts.join(" "))
-    }
+    parts.join(" ")
+}
+
+/// Both forms of one schema.org duration field: the display prose and the
+/// sortable minute count, from a single parse of the ISO-8601 value.
+fn scraped_time(value: Option<&ld_schema::StringOrList>) -> (Option<String>, Option<u32>) {
+    let minutes = value
+        .and_then(|t| t.first_str())
+        .and_then(parse_iso8601_duration);
+    (minutes.map(humanize_minutes), minutes)
 }
 
 /// Extract equipment names from schema.org HowTo `tool`, which may be a bare
@@ -254,23 +267,18 @@ fn normalize_root_recipe(
         .unwrap_or((None, None));
 
     // Humanize the ISO-8601 durations; `active` has no schema.org source.
+    let (total, total_minutes) = scraped_time(ld_schema.total_time.as_ref());
+    let (prep, prep_minutes) = scraped_time(ld_schema.prep_time.as_ref());
+    let (cook, cook_minutes) = scraped_time(ld_schema.cook_time.as_ref());
     let times = RecipeTimes {
         active: None,
-        total: ld_schema
-            .total_time
-            .as_ref()
-            .and_then(|t| t.first_str())
-            .and_then(humanize_iso8601_duration),
-        prep: ld_schema
-            .prep_time
-            .as_ref()
-            .and_then(|t| t.first_str())
-            .and_then(humanize_iso8601_duration),
-        cook: ld_schema
-            .cook_time
-            .as_ref()
-            .and_then(|t| t.first_str())
-            .and_then(humanize_iso8601_duration),
+        total,
+        prep,
+        cook,
+        active_minutes: None,
+        total_minutes,
+        prep_minutes,
+        cook_minutes,
     };
 
     let equipment = ld_schema
@@ -394,8 +402,9 @@ mod tests {
     use crate::{
         RecipeYield,
         ld_json::{
-            extract_ld, extract_tool_names, extract_yield_from_wrapper, humanize_iso8601_duration,
-            normalize_ld_json, parse_ld_json, parse_yield_string, scrape_from_ld_json,
+            extract_ld, extract_tool_names, extract_yield_from_wrapper, humanize_minutes,
+            normalize_ld_json, parse_iso8601_duration, parse_ld_json, parse_yield_string,
+            scrape_from_ld_json,
         },
         ld_schema::{InstructionWrapper, RecipeYieldWrapper, Root, RootRecipe},
     };
@@ -701,36 +710,51 @@ mod tests {
     }
 
     // ============================================================================
-    // humanize_iso8601_duration() Tests
+    // parse_iso8601_duration() / humanize_minutes() Tests
     // ============================================================================
 
+    // One case list covers both halves: the minute count is what production
+    // stores for sorting, the prose is what it displays, and they must agree
+    // about which inputs are durations at all.
     #[rstest]
-    #[case::minutes("PT35M", Some("35 minutes"))]
-    #[case::one_minute("PT1M", Some("1 minute"))]
-    #[case::hour_and_minutes("PT1H30M", Some("1 hour 30 minutes"))]
-    #[case::leading_zero_hours("PT0H15M", Some("15 minutes"))]
-    #[case::whole_hours("PT2H", Some("2 hours"))]
-    #[case::one_hour("PT1H", Some("1 hour"))]
+    #[case::minutes("PT35M", Some("35 minutes"), Some(35))]
+    #[case::one_minute("PT1M", Some("1 minute"), Some(1))]
+    #[case::hour_and_minutes("PT1H30M", Some("1 hour 30 minutes"), Some(90))]
+    #[case::leading_zero_hours("PT0H15M", Some("15 minutes"), Some(15))]
+    #[case::whole_hours("PT2H", Some("2 hours"), Some(120))]
+    #[case::one_hour("PT1H", Some("1 hour"), Some(60))]
     // Seconds are consumed but dropped; with only seconds there's nothing to show.
-    #[case::seconds_only("PT45S", None)]
-    #[case::hour_minute_seconds("PT1H5M30S", Some("1 hour 5 minutes"))]
-    #[case::zero("PT0M", None)]
-    #[case::no_prefix("35M", None)]
-    #[case::garbage("nonsense", None)]
-    #[case::empty("", None)]
+    #[case::seconds_only("PT45S", None, None)]
+    #[case::hour_minute_seconds("PT1H5M30S", Some("1 hour 5 minutes"), Some(65))]
+    #[case::zero("PT0M", None, None)]
+    #[case::no_prefix("35M", None, None)]
+    #[case::garbage("nonsense", None, None)]
+    #[case::empty("", None, None)]
+    // Trailing digits with no unit aren't a duration.
+    #[case::trailing_digits("PT1H30", None, None)]
     // Date part: a day count is accepted (WP Recipe Maker emits P0DT0H30M);
     // days fold into hours. Non-day date parts aren't recipe durations.
-    #[case::zero_days("P0DT1H30M", Some("1 hour 30 minutes"))]
-    #[case::days_and_hours("P1DT2H", Some("26 hours"))]
-    #[case::days_only("P1D", Some("24 hours"))]
-    #[case::months_rejected("P1M", None)]
+    #[case::zero_days("P0DT1H30M", Some("1 hour 30 minutes"), Some(90))]
+    #[case::days_and_hours("P1DT2H", Some("26 hours"), Some(1560))]
+    #[case::days_only("P1D", Some("24 hours"), Some(1440))]
+    #[case::months_rejected("P1M", None, None)]
+    #[case::years_rejected("P1Y", None, None)]
+    #[case::weeks_rejected("P2W", None, None)]
     // Regression: an absurd day count from adversarial HTML must not panic
-    // (debug) or wrap (release) on `days * 24`; checked arithmetic rejects it.
-    #[case::days_overflow("P1000000000000000000D", None)]
-    fn test_humanize_iso8601_duration(#[case] input: &str, #[case] expected: Option<&str>) {
+    // (debug) or wrap (release) on the day-to-minute conversion; checked
+    // arithmetic and the u32 minute count reject it.
+    #[case::days_overflow("P1000000000000000000D", None, None)]
+    #[case::days_beyond_u32_minutes("P100000000D", None, None)]
+    fn test_parse_iso8601_duration(
+        #[case] input: &str,
+        #[case] expected_prose: Option<&str>,
+        #[case] expected_minutes: Option<u32>,
+    ) {
+        let minutes = parse_iso8601_duration(input);
+        assert_eq!(minutes, expected_minutes);
         assert_eq!(
-            humanize_iso8601_duration(input),
-            expected.map(|s| s.to_string())
+            minutes.map(humanize_minutes),
+            expected_prose.map(|s| s.to_string())
         );
     }
 

--- a/recipe-types/src/lib.rs
+++ b/recipe-types/src/lib.rs
@@ -76,6 +76,12 @@ pub struct RecipeYield {
 /// Printed times. Any field may be absent. Shared workspace-wide: the web scraper
 /// fills it from JSON-LD ISO-8601 durations, `recipe-epub` from the model's output.
 /// `active` has no JSON-LD source, so it stays `None` for scraped recipes.
+///
+/// Each time is carried twice: the `*_minutes` field is the same duration as a
+/// number, so consumers can sort and filter without re-parsing the prose. The
+/// strings stay the display form (they preserve how the source wrote it); the
+/// minutes are derived and may be `None` where the prose couldn't be parsed
+/// confidently, so a present string does NOT imply a present count.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
 pub struct RecipeTimes {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -86,12 +92,28 @@ pub struct RecipeTimes {
     pub prep: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cook: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_minutes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_minutes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prep_minutes: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cook_minutes: Option<u32>,
 }
 
 impl RecipeTimes {
     /// `true` when every field is absent (so callers can collapse to `None`).
+    /// The minute counts count: a row carrying only numbers is still a time.
     pub fn is_empty(&self) -> bool {
-        self.active.is_none() && self.total.is_none() && self.prep.is_none() && self.cook.is_none()
+        self.active.is_none()
+            && self.total.is_none()
+            && self.prep.is_none()
+            && self.cook.is_none()
+            && self.active_minutes.is_none()
+            && self.total_minutes.is_none()
+            && self.prep_minutes.is_none()
+            && self.cook_minutes.is_none()
     }
 }
 


### PR DESCRIPTION
## Why

`RecipeTimes` has only ever carried prose — `PT1H30M` became `"1 hour 30 minutes"` and the number was thrown away. A consumer that wants to **sort or filter a recipe list by total time** therefore has to re-parse the humanized English, which is exactly the layering violation this workspace exists to prevent. The number has to come from here.

## What

Each time is now carried twice: the string stays the display form, the new `*_minutes` count is what gets sorted. Both halves are `Option` + `skip_serializing_if`, so the wire format is unchanged for anything that doesn't ask for the new fields, and a present string does **not** imply a present count.

**`recipe-types`** — `RecipeTimes` gains `active_minutes` / `total_minutes` / `prep_minutes` / `cook_minutes` (`Option<u32>`), following the existing serde attributes. `is_empty()` now considers them: a row carrying only numbers is still a time.

**`recipe-scraper`** — the ISO-8601 value is parsed once. `parse_iso8601_duration` returns whole minutes; `humanize_minutes` renders the prose *from that number*, so the two can't drift, and `scraped_time` hands the call site both. Behavior is unchanged for every input the old humanizer rejected — non-`P…`, years/months/weeks, trailing digits with no unit, zero-length durations. One deliberate difference: a duration too large to fit the minute count is now rejected rather than printed as an absurd hour string.

**`recipe-epub`** — its times come from the model's freeform output, so they're read strictly: the whole string must be hour/minute counts (one leading hedge like "about" or `~` aside), or there is no count. Ranges, fractions, trailing qualifiers, and bare words all keep their display string and get `None` — a wrong number is worse than no number. The fill happens in `parse_recipes_payload`, the single place LLM output is decoded, so the native and wasm paths share it. The LLM tool schema is untouched; the numbers are derived, never asked for.

**`ingredient-wasm`** — `WRecipeTimes` mirrors the four new fields across the boundary.

## Tests

- `recipe-scraper`: the existing `humanize_iso8601_duration` rstest becomes one case list asserting **both** halves, so prose and count can never disagree about what counts as a duration. New cases for years/weeks rejection, trailing digits, and a day count that overflows the minute counter.
- `recipe-epub`: a 21-case rstest over the freeform shapes (`30 minutes`, `1 hr 15 min`, `1 hr. 15 min.`, `~45 min`, mixed case) and every shape that must yield `None` (ranges, `1 1/2 hours`, `30 minutes, plus chilling`, `overnight`, unit-less, `0 minutes`), plus an end-to-end check that a payload's prose fills the counts and unreadable prose keeps its string with no count.

`cargo fmt --check`, `cargo clippy --all-targets`, and `cargo test` all pass from the workspace root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)