### PR TITLE
feat(recipe-epub): expose dc:identifier on EpubMeta

### DIFF
--- a/recipe-epub/src/backend.rs
+++ b/recipe-epub/src/backend.rs
@@ -1322,6 +1322,17 @@ mod tests {
         zw.finish().unwrap().into_inner()
     }
 
+    /// `dc:identifier` reaches `EpubMeta` verbatim. It is the only book-level
+    /// field that can carry an ISBN, which is what lets a consumer match an
+    /// imported cookbook to the physical copy by identity instead of by title
+    /// — and title matching is exactly what confuses two different books that
+    /// share a name.
+    #[test]
+    fn epub_metadata_exposes_dc_identifier() {
+        let meta = crate::epub_metadata(&minimal_epub()).unwrap();
+        assert_eq!(meta.identifiers, vec!["urn:uuid:failing-book".to_string()]);
+    }
+
     /// A chunk whose extraction fails (no escalation configured) must be
     /// counted in `chunks_failed` and NOT silently treated as "found nothing
     /// here" — the whole point of the counter (see the `backend.rs:300`

--- a/recipe-epub/src/lib.rs
+++ b/recipe-epub/src/lib.rs
@@ -689,10 +689,18 @@ pub struct EpubMeta {
     pub authors: Vec<String>,
     /// OPF `<dc:subject>` tags (Calibre genres). Often empty.
     pub subjects: Vec<String>,
+    /// OPF `<dc:identifier>` values, verbatim and unfiltered. A book usually
+    /// declares several in different schemes — `urn:uuid:...`, `urn:isbn:...`,
+    /// a bare ISBN, a Calibre id — and the OPF's `unique-identifier` attribute
+    /// names whichever one it considers canonical. Nothing here interprets or
+    /// ranks them: which scheme a consumer wants is the consumer's business,
+    /// and dropping the ones this crate doesn't recognise would be lossy.
+    pub identifiers: Vec<String>,
 }
 
-/// Extract title/authors/subjects from an already-open EPUB's OPF. Shared by the
-/// wasm-safe [`epub_metadata`] and the file-backed [`book_metadata`].
+/// Extract title/authors/subjects/identifiers from an already-open EPUB's OPF.
+/// Shared by the wasm-safe [`epub_metadata`] and the file-backed
+/// [`book_metadata`].
 pub(crate) fn meta_from_doc<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>) -> EpubMeta {
     let collect = |prop: &str| -> Vec<String> {
         doc.metadata
@@ -710,10 +718,11 @@ pub(crate) fn meta_from_doc<R: std::io::Read + std::io::Seek>(doc: &EpubDoc<R>) 
             .unwrap_or_default(),
         authors: collect("creator"),
         subjects: collect("subject"),
+        identifiers: collect("identifier"),
     }
 }
 
-/// Title/authors/subjects from an in-memory EPUB's OPF — the wasm-safe metadata
+/// Title/authors/subjects/identifiers from an in-memory EPUB's OPF — the wasm-safe metadata
 /// read (`EpubDoc::from_reader`, no fs). `None` if the bytes aren't a readable
 /// EPUB. Pure: parses only the OPF the EPUB loads on open.
 pub fn epub_metadata(bytes: &[u8]) -> Option<EpubMeta> {


### PR DESCRIPTION
## Why

An imported cookbook can only be matched to a physical copy by title, and title matching is exactly what confuses two different books that share a name — "Tartine Book No. 3" and "Tartine: A Classic Revisited" are different books.

`dc:identifier` is the only book-level OPF field that can carry an ISBN, so surfacing it lets a consumer match by identity instead of by name.

## What

`EpubMeta` gains `identifiers: Vec<String>`, collected the same way `authors` and `subjects` already are.

Values are passed through **verbatim and unranked**. A book usually declares several in different schemes (`urn:uuid:`, `urn:isbn:`, a bare ISBN, a Calibre id), and the OPF's own `unique-identifier` attribute frequently names the Calibre UUID rather than the ISBN — so ranking them here would be wrong as often as right. Which scheme a consumer wants is the consumer's business, and dropping the ones this crate doesn't recognise would be lossy.

## Consumer

Cubby's `recipebridge` forwards this to the browser, where `isbnFromEpubIdentifiers` scans every value for one that passes an ISBN check digit and normalizes it to a canonical GTIN-14. Scanning all of them is safe precisely because nothing that isn't an ISBN can pass that check.

## Testing

`cargo fmt`, `cargo clippy --all-targets`, and 107 tests pass. New test `epub_metadata_exposes_dc_identifier` pins the field against the existing `minimal_epub()` fixture, which already declared a `dc:identifier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)