### PR TITLE
Add opt-in shopping formatting and canonical conversion helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/ingredient-parser/src/unit/conversion.rs
+++ b/ingredient-parser/src/unit/conversion.rs
@@ -18,6 +18,38 @@ use tracing::debug;
 
 pub type MeasureGraph = Graph<Unit, EdgeFactor>;
 
+/// Pick the measure a multi-amount ingredient should resolve from.
+///
+/// A stated weight is preferred over the written order because it is directly
+/// comparable across products. If no weight is present, retain the first amount
+/// as written. An amount-less ingredient has no canonical measure.
+pub fn canonical_amount(amounts: &[Measure]) -> Option<&Measure> {
+    amounts
+        .iter()
+        .find(|measure| matches!(measure.kind(), MeasureKind::Weight))
+        .or_else(|| amounts.first())
+}
+
+/// Convert written amounts to a target kind, preferring the canonical amount.
+///
+/// If that preferred measure has no path to `target`, retry every written amount
+/// in input order. This keeps the canonical basis when possible while allowing,
+/// for example, a later volume measure to provide a price when the preferred
+/// weight has no money mapping.
+pub fn convert_with_fallback(
+    amounts: &[Measure],
+    graph: &MeasureGraph,
+    target: MeasureKind,
+) -> Option<Measure> {
+    canonical_amount(amounts)
+        .and_then(|measure| convert_measure_with_graph(measure, target.clone(), graph))
+        .or_else(|| {
+            amounts
+                .iter()
+                .find_map(|measure| convert_measure_with_graph(measure, target.clone(), graph))
+        })
+}
+
 /// A directed edge's conversion factor as a closed interval `[lower, upper]`.
 ///
 /// For an ordinary point mapping (the common case — "1 cup = 120 g", a price, a
@@ -534,6 +566,87 @@ pub(crate) fn convert_measure_via_mappings(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn canonical_amount_prefers_the_first_weight() {
+        let amounts = [
+            Measure::new("cup", 1.0),
+            Measure::new("g", 50.0),
+            Measure::new("oz", 2.0),
+        ];
+
+        assert_eq!(canonical_amount(&amounts), Some(&amounts[1]));
+    }
+
+    #[test]
+    fn canonical_amount_uses_first_amount_or_none() {
+        let amounts = [Measure::new("cup", 1.0), Measure::new("tbsp", 2.0)];
+
+        assert_eq!(canonical_amount(&amounts), Some(&amounts[0]));
+        assert_eq!(canonical_amount(&[]), None);
+    }
+
+    #[test]
+    fn convert_with_fallback_uses_first_reachable_written_amount() {
+        let graph = make_graph(&[
+            (Measure::new("first", 1.0), Measure::new("$", 2.0)),
+            (Measure::new("second", 1.0), Measure::new("$", 1.0)),
+        ]);
+        let amounts = [
+            Measure::new("g", 100.0),
+            Measure::new("first", 1.0),
+            Measure::new("second", 1.0),
+        ];
+
+        assert_eq!(
+            convert_with_fallback(&amounts, &graph, MeasureKind::Money),
+            Some(Measure::new("$", 2.0))
+        );
+    }
+
+    #[test]
+    fn convert_with_fallback_keeps_the_canonical_conversion_when_it_reaches() {
+        let graph = make_graph(&[
+            (Measure::new("first", 1.0), Measure::new("$", 2.0)),
+            (Measure::new("g", 100.0), Measure::new("$", 1.0)),
+        ]);
+        let amounts = [Measure::new("first", 1.0), Measure::new("g", 100.0)];
+
+        assert_eq!(
+            convert_with_fallback(&amounts, &graph, MeasureKind::Money),
+            Some(Measure::new("$", 1.0))
+        );
+    }
+
+    #[test]
+    fn convert_with_fallback_returns_none_without_a_target_path() {
+        let graph = make_graph(&[(Measure::new("cup", 1.0), Measure::new("g", 120.0))]);
+        let amounts = [Measure::new("g", 100.0), Measure::new("cup", 1.0)];
+
+        assert_eq!(
+            convert_with_fallback(&amounts, &graph, MeasureKind::Money),
+            None
+        );
+    }
+
+    #[test]
+    fn convert_with_fallback_returns_none_for_empty_amounts() {
+        assert_eq!(
+            convert_with_fallback(&[], &make_graph(&[]), MeasureKind::Money),
+            None
+        );
+    }
+
+    #[test]
+    fn convert_with_fallback_preserves_conversion_ranges() {
+        let graph = make_graph(&[(Measure::new("cup", 1.0), Measure::with_range("$", 2.0, 4.0))]);
+        let amounts = [Measure::new("g", 100.0), Measure::new("cup", 2.0)];
+
+        assert_eq!(
+            convert_with_fallback(&amounts, &graph, MeasureKind::Money),
+            Some(Measure::with_range("$", 4.0, 8.0))
+        );
+    }
 
     #[test]
     fn mapping_target_kind_uses_normalized_graph_node() {

--- a/ingredient-parser/src/unit/measure.rs
+++ b/ingredient-parser/src/unit/measure.rs
@@ -698,6 +698,29 @@ impl Measure {
         }
     }
 
+    /// Format this measure with the larger units a shopper would expect on a list.
+    ///
+    /// This is intentionally opt-in: [`std::fmt::Display`] continues to render
+    /// the parser's regular denormalized form. Grams only become pounds at one
+    /// pound, and milliliters only become liters at one liter; every other unit
+    /// uses the regular formatter unchanged.
+    pub fn format_shopper(&self) -> String {
+        let measure = self.denormalize();
+        let value = measure.value();
+        let (unit, factor) = match measure.unit() {
+            Unit::Gram if value >= GRAM_TO_OZ * OZ_TO_LB => (Unit::Pound, GRAM_TO_OZ * OZ_TO_LB),
+            Unit::Milliliter if value >= G_TO_K => (Unit::Liter, G_TO_K),
+            _ => return measure.to_string(),
+        };
+
+        Measure::new_with_upper(
+            unit,
+            value / factor,
+            measure.upper_value().map(|upper| upper / factor),
+        )
+        .to_string()
+    }
+
     /// Convert this measure to a target kind using user-provided mappings.
     ///
     /// This is a convenience wrapper around `convert_measure_via_mappings`.
@@ -988,6 +1011,59 @@ mod tests {
     fn test_second_denormalize_unit(#[case] value: f64, #[case] expected: Unit) {
         let m = Measure::new_with_upper(Unit::Second, value, None);
         assert_eq!(*m.denormalize().unit(), expected);
+    }
+
+    // ============================================================================
+    // Shopper Formatting (opt-in; Display and denormalize stay unchanged)
+    // ============================================================================
+
+    #[rstest]
+    #[case::one_pound_threshold("g", GRAM_TO_OZ * OZ_TO_LB, "1 lb")]
+    #[case::above_pound_threshold("g", 1360.0, "3 lb")]
+    #[case::five_hundred_grams("g", 500.0, "1.1 lb")]
+    #[case::below_pound_threshold("g", 300.0, "300 g")]
+    #[case::one_liter_threshold("ml", G_TO_K, "1 l")]
+    #[case::above_liter_threshold("ml", 1500.0, "1½ l")]
+    #[case::below_liter_threshold("ml", 250.0, "250 ml")]
+    #[case::zero("g", 0.0, "0 g")]
+    #[case::negative("ml", -1500.0, "-1500 ml")]
+    #[case::passthrough_count("whole", 3.0, "3")]
+    #[case::existing_volume_ladder("tsp", 48.0, "1 cup")]
+    fn test_measure_format_shopper(#[case] unit: &str, #[case] value: f64, #[case] expected: &str) {
+        assert_eq!(Measure::new(unit, value).format_shopper(), expected);
+    }
+
+    #[test]
+    fn test_measure_format_shopper_scales_ranges_together() {
+        let shopper = Measure::with_range("g", 1000.0, 2000.0).format_shopper();
+        assert_eq!(shopper, "2.2 - 4.41 lb");
+    }
+
+    #[test]
+    fn test_measure_format_shopper_only_changes_at_the_lower_threshold() {
+        let pound = GRAM_TO_OZ * OZ_TO_LB;
+        let just_below = Measure::new("g", pound - 0.01);
+        let just_above = Measure::new("g", pound + 0.01);
+        let range_crossing_threshold = Measure::with_range("g", 300.0, 1000.0);
+        let upper_only_range = Measure::with_range("g", 0.0, 1000.0);
+
+        assert_eq!(just_below.format_shopper(), just_below.to_string());
+        assert_eq!(just_above.format_shopper(), "1 lb");
+        assert_eq!(
+            range_crossing_threshold.format_shopper(),
+            range_crossing_threshold.to_string()
+        );
+        assert_eq!(
+            upper_only_range.format_shopper(),
+            upper_only_range.to_string()
+        );
+    }
+
+    #[test]
+    fn test_measure_format_shopper_does_not_change_default_formatting() {
+        let measure = Measure::new("g", 1360.0);
+        assert_eq!(measure.denormalize(), measure);
+        assert_eq!(measure.to_string(), "1360 g");
     }
 
     // ============================================================================

--- a/ingredient-parser/src/unit/mod.rs
+++ b/ingredient-parser/src/unit/mod.rs
@@ -8,8 +8,9 @@ pub use kind::MeasureKind;
 
 pub mod conversion;
 pub use conversion::{
-    ConversionStep, convert_measure_with_graph, convert_measure_with_graph_explained,
-    find_connected_components, mapping_graph_unit, mapping_target_kind,
+    ConversionStep, canonical_amount, convert_measure_with_graph,
+    convert_measure_with_graph_explained, convert_with_fallback, find_connected_components,
+    mapping_graph_unit, mapping_target_kind,
 };
 
 pub(crate) mod measure;


### PR DESCRIPTION
Add opt-in `Measure::format_shopper()` and `ingredient::unit::{canonical_amount, convert_with_fallback}`.

Shopping formatting reuses existing unit factors, preserves ranges and leaves default formatting unchanged. Conversion prefers the first weight, falling back through written amounts only when needed.

Tested with workspace build/nextest, doctests, strict Clippy and hooks. Cases cover thresholds, ranges, canonical preference and fallback order. A separate lockfile commit replaces yanked `chacha20 0.10.0` with compatible `0.10.2` to clear cargo-deny.

Independent of #372.
