### PR TITLE
Share EPUB extraction orchestration across native and browser callers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,12 +43,13 @@ jobs:
         run: cargo nextest run --workspace --profile ci
       - name: Run doctests
         run: cargo test -p ingredient --doc
-      # cubby's recipebridge builds recipe-epub with `default-features = false`
-      # and drives extraction in the browser. Nothing in THIS repo calls that
-      # half, so only this check stops a `native`-only import from silently
-      # breaking a downstream that has no version gate (see CONTRIBUTING.md).
+      # Browser callers build recipe-epub with `default-features = false`
+      # and supply browser transport to the shared driver. Keep the complete
+      # runtime-independent interface buildable for that downstream.
       - name: Check recipe-epub's pure (non-native) half still compiles
-        run: cargo check -p recipe-epub --no-default-features
+        run: |
+          cargo check -p recipe-epub --no-default-features
+          cargo test -p recipe-epub --no-default-features --lib
   wasm-tests:
     name: wasm tests (headless)
     runs-on: ubuntu-latest
@@ -70,6 +71,10 @@ jobs:
         uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2
       - name: Run wasm-bindgen tests
         run: wasm-pack test --headless --chrome ingredient-wasm
+      - name: Check browser EPUB orchestration example
+        run: >-
+          cargo check -p recipe-epub --target wasm32-unknown-unknown
+          --no-default-features --example browser_callback
   coverage:
     name: code coverage
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,10 @@
 
 ## Before deleting a `pub` item
 
-`recipe-scraper`, `recipe-epub` and `recipe-types` are `publish = false` but are
-consumed by cubby via an unpinned git dependency, so zero callers in this repo
-does NOT mean dead. Check `../cubby/recipebridge/src/` first. `ingredient-corpus`,
-`food-cli` and `food-app` have no external consumer. See CONTRIBUTING.md.
+`recipe-scraper`, `recipe-epub` and `recipe-types` are `publish = false` but have
+external consumers. Zero callers in this repo does not prove a public API is
+unused. Preserve compatibility and check any consumer code supplied with the
+task before narrowing an API. See CONTRIBUTING.md.
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,22 +22,12 @@ when deciding what a line *should* parse to.
 
 ## Downstream consumers
 
-Only `ingredient-parser` is published (as `ingredient`). The other library
-crates are `publish = false`, which normally means "internal, change freely" —
-**they aren't.** [cubby](https://github.com/nickysemenza/cubby)'s `recipebridge`
-depends on `ingredient`, `recipe-scraper`, `recipe-epub` and `recipe-types` by
-git branch with no rev pin, and gitignores its lockfile, so a breaking change
-here breaks its CI on the next run with no semver step to absorb it.
+Only `ingredient-parser` is published (as `ingredient`). The library crates
+`recipe-scraper`, `recipe-epub` and `recipe-types` also have external git consumers.
+Treat their public APIs as compatibility contracts even when no workspace caller
+uses them. Prefer additive changes; coordinate breaking changes with consumers.
 
-- **A repo-local caller search is not evidence a `pub` item in those four is
-  unused.** cubby is the only consumer of much of the unit-conversion surface
-  (`find_connected_components`, `make_graph`, `convert_measure_with_graph_explained`,
-  `is_valid`, `util::format_quantity_ascii`) and of `recipe-epub`'s entire
-  non-`native` half.
-- Additive changes are safe. Narrowing one is a two-repo change: prepare the
-  cubby side first.
-- `ingredient-corpus`, `food-cli` and `food-app` have no external consumer, so
-  for those a local search *is* evidence.
+`ingredient-corpus`, `food-cli` and `food-app` have no external consumers.
 
 ## Quick commands
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/food-cli/src/main.rs
+++ b/food-cli/src/main.rs
@@ -57,15 +57,12 @@ enum Commands {
         #[arg(long)]
         no_cache: bool,
     },
-    /// Debug a single EPUB: re-run every chunk through the model and report any
-    /// whose raw payload fails to deserialize, with the offending JSON path. This
-    /// is the view `scrape-epub` HIDES — it silently skips bad chunks (and the
-    /// wasm cookbook import aborts the whole book on the first one). Bypasses the
-    /// cache. Defaults to `claude-haiku-4-5` to mirror cubby's cookbook import.
+    /// Debug a single EPUB: re-run every chunk and report malformed payloads.
+    /// Bypasses the cache. Defaults to `claude-haiku-4-5`.
     DebugEpub {
         /// Path to the .epub file
         path: String,
-        /// Model id override (default: claude-haiku-4-5, matching cubby's import)
+        /// Model id override (default: claude-haiku-4-5)
         #[arg(long)]
         model: Option<String>,
         /// Print the full raw JSON payload of each failed chunk (can be large)
@@ -425,9 +422,7 @@ async fn main() {
                 eprintln!("failed to read {path}: {e}");
                 std::process::exit(1);
             });
-            // Default to Haiku (cubby's cookbook-import model) so a failure here
-            // reproduces the real import; the cache is off because a failed parse
-            // is never cached anyway and we want a live payload every run.
+            // Disable caching to inspect a fresh payload on every run.
             let opts = recipe_epub::Options {
                 model: Some(
                     model

--- a/ingredient-parser/src/parser/refine/units.rs
+++ b/ingredient-parser/src/parser/refine/units.rs
@@ -51,7 +51,7 @@ impl IngredientParser {
     /// counted item: "3 medium carrots" -> `{medium:3}` carrots, "2 extra large
     /// eggs" -> `{extra large:2}` eggs. This lets the size map to USDA portion data
     /// through the unit graph — a bare `{whole}` count is not a USDA portion key,
-    /// the size is (cubby already maps "1 each = 1 large" on its egg product).
+    /// the size is (for example, a mapping can relate "1 each" to "1 large").
     ///
     /// Fires only when a real `Unit::Whole` count is present (so "medium heat", a
     /// no-count "medium onion", and "2 cups large onion" are all untouched), the

--- a/ingredient-parser/src/unit/core.rs
+++ b/ingredient-parser/src/unit/core.rs
@@ -270,8 +270,8 @@ fn strip_plural(s: &str) -> &str {
 }
 
 /// Lowercase + strip a plural suffix from a unit word ("Scoops" -> "scoop",
-/// "pouches" -> "pouch"). Public because downstream boundary code (e.g.
-/// recipebridge's bare-count serving guard) must relabel units with exactly
+/// "pouches" -> "pouch"). Public because downstream boundary code
+/// must relabel units with exactly
 /// the form this parser would read off a recipe line — reimplementing the
 /// rule there would drift.
 pub fn singular(s: &str) -> Cow<'_, str> {

--- a/ingredient-parser/tests/corpus/corpus.jsonl
+++ b/ingredient-parser/tests/corpus/corpus.jsonl
@@ -403,7 +403,7 @@
 {"input": "2 tablespoons XFF Chili Oil", "name": "XFF Chili Oil", "amounts": [{"unit": "tbsp", "value": 2.0}]}
 {"input": "8 cups (2 L) lamb broth", "name": "lamb broth", "amounts": [{"unit": "cup", "value": 8.0}, {"unit": "l", "value": 2.0}]}
 {"input": "1 teaspoon XFF Chili Oil (this page; optional)", "name": "XFF Chili Oil", "amounts": [{"unit": "tsp", "value": 1.0}], "optional": true}
-// Real cubby cookbook-import lines that older parses mangled (parser-audit): a
+// Real cookbook-import lines that older parses mangled (parser-audit): a
 // stranded intensifier ("very") before a prep phrase, and non-standard quantity
 // units "recipes"/"loaf" that must be hoisted out of the name into the amounts.
 {"input": "2 tablespoons very thinly sliced chives", "name": "chives", "amounts": [{"unit": "tbsp", "value": 2}], "modifier": "very thinly sliced"}
@@ -450,7 +450,7 @@
 {"input": "1 cup fried onions", "name": "fried onions", "amounts": [{"unit": "cup", "value": 1}]}
 {"input": "2 tablespoons unsalted butter, plus more for greasing", "name": "unsalted butter", "amounts": [{"unit": "tbsp", "value": 2}], "modifier": "plus more for greasing"}
 
-// --- cubby cookbook-import fixes (2026-06-12): postfix produce units, bare
+// --- cookbook-import fixes (2026-06-12): postfix produce units, bare
 // --- grated, for-<gerund> purpose clause, mid-"and" guard, fresh-as-implied ---
 // FIX 1: postfix produce count-unit (garlic clove → {clove:1} garlic), size range to modifier.
 {"input": "1 medium or large garlic clove, peeled", "name": "garlic", "amounts": [{"unit": "clove", "value": 1}], "modifier": "medium or large, peeled"}
@@ -507,7 +507,7 @@
 {"input": "1 cup (130g) shredded zucchini (see note)*", "name": "zucchini", "amounts": [{"unit": "cup", "value": 1.0}, {"unit": "g", "value": 130.0}], "modifier": "shredded"}
 {"input": "1 cup shredded cheddar cheese", "name": "cheddar cheese", "amounts": [{"unit": "cup", "value": 1.0}], "modifier": "shredded"}
 
-// --- cubby cookbook-import fixes (2026-06-23) ---
+// --- cookbook-import fixes (2026-06-23) ---
 // Inline "A or B <head noun>" distributes the trailing head noun onto the primary
 // (vocab::DISTRIBUTABLE_HEAD_NOUNS), so the head is no longer dropped.
 {"input": "4 cups chicken or vegetable stock", "name": "chicken stock", "amounts": [{"unit": "cup", "value": 4}], "modifier": "or vegetable stock"}
@@ -542,7 +542,7 @@
 {"input": "tub of yogurt", "name": "yogurt", "amounts": [{"unit": "tub", "value": 1}]}
 {"input": "bag of all-purpose flour", "name": "all-purpose flour", "amounts": [{"unit": "bag", "value": 1}]}
 
-// --- cubby cookbook-import fixes (2026-06-27) ---
+// --- cookbook-import fixes (2026-06-27) ---
 {"input": "2 cups cubed seedless watermelon (from about ¼ small melon), chilled", "name": "seedless watermelon", "amounts": [{"unit": "cup", "value": 2}], "modifier": "cubed (from about ¼ small melon), chilled"}
 {"input": "½ cup unsalted peanuts", "name": "unsalted peanuts", "amounts": [{"unit": "cup", "value": 0.5}]}
 {"input": "1 medium purple (red) cabbage (about 1 pound)", "name": "purple (red) cabbage", "amounts": [{"unit": "medium", "value": 1}, {"unit": "lb", "value": 1}]}

--- a/recipe-epub/Cargo.toml
+++ b/recipe-epub/Cargo.toml
@@ -12,14 +12,13 @@ publish = false
 
 # The `native` feature carries everything that can't compile to
 # wasm32-unknown-unknown: the reqwest-based LLM backends, the std::fs extraction
-# cache, and the async/tokio orchestration. With `default-features = false` only
-# the pure pipeline remains — EPUB unzip + text chunking (`chunk_epub`), request
-# building (`build_chunk_request`), LLM response parsing, and assembly
-# (`assemble_recipes`) — for a potential future wasm consumer; every current
-# in-tree consumer keeps `native`.
+# cache, and Tokio-backed entry points. With `default-features = false` the
+# runtime-independent pipeline remains: EPUB chunking, request/response handling,
+# whole-book orchestration, and assembly. Browser callers provide their own
+# extraction transport through `extract_chunks_with`.
 [features]
 default = ["native"]
-native = ["dep:reqwest", "dep:tokio", "dep:futures", "dep:walkdir"]
+native = ["dep:reqwest", "dep:tokio", "dep:walkdir"]
 
 [dependencies]
 epub = "2.1.5"
@@ -33,14 +32,14 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+futures.workspace = true
 # Native-only: HTTP client + async runtime for the live LLM extractors. Excluded
 # from the wasm build, which proxies the LLM call through JS instead.
 reqwest = { version = "0.13", features = ["json"], optional = true }  # default TLS is rustls in 0.13
 tokio = { workspace = true, optional = true }
-futures = { workspace = true, optional = true }
 walkdir = { version = "2", optional = true }  # recursive epub discovery (native fs only)
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 rstest.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 zip = "8"  # build tiny in-memory EPUB fixtures (epub itself reads via zip 3)

--- a/recipe-epub/examples/browser_callback.rs
+++ b/recipe-epub/examples/browser_callback.rs
@@ -1,0 +1,62 @@
+//! Browser-compatible whole-book extraction without native features.
+//!
+//! A real wasm adapter replaces the body of `call_model` with its JavaScript
+//! Promise bridge. The shared driver does not require `Send` futures: this
+//! example deliberately captures `Rc<RefCell<_>>`, which is local to a browser
+//! thread.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use recipe_epub::{
+    CallFailure, CallResult, Chunk, ChunkOutcome, ExtractionReport, ModelTier,
+    OrchestrationOptions, Usage, extract_chunks_with, try_extract_chunk_detailed,
+};
+
+/// Drive chunks with a browser-local transport. This concrete example returns
+/// empty tool output; a JS adapter would deserialize its proxy response into
+/// `CallResult` and retain usage/truncation metadata when available.
+pub async fn browser_callback_example(chunks: Vec<Chunk>) -> ExtractionReport {
+    let calls = Rc::new(RefCell::new(Vec::new()));
+    extract_chunks_with(
+        chunks,
+        "browser.epub",
+        &OrchestrationOptions {
+            concurrency: 4,
+            fallback: true,
+            previews: true,
+        },
+        move |index, chunk, tier| {
+            let calls = Rc::clone(&calls);
+            async move {
+                calls.borrow_mut().push((index, tier));
+                let driven = try_extract_chunk_detailed(&chunk.doc_path, || async {
+                    call_model(&chunk, tier).await
+                })
+                .await?;
+                Ok(ChunkOutcome {
+                    recipes: driven.recipes,
+                    usage: driven.usage,
+                    cached: false,
+                    truncated: driven.truncated,
+                })
+            }
+        },
+        |_snapshot| {
+            // Serialize `snapshot.preview` for an incremental browser preview.
+        },
+    )
+    .await
+}
+
+async fn call_model(_chunk: &Chunk, _tier: ModelTier) -> Result<CallResult, CallFailure> {
+    Ok(CallResult {
+        input: None,
+        usage: Usage::default(),
+        truncated: false,
+    })
+}
+
+fn main() {
+    // The example is compile-checked for wasm32 with default features disabled.
+}

--- a/recipe-epub/src/backend.rs
+++ b/recipe-epub/src/backend.rs
@@ -8,18 +8,17 @@
 #![cfg(feature = "native")]
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
-use futures::stream::{self, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
 
 use crate::library::BookMeta;
 use crate::{
-    CallResult, Chunk, ChunkOutcome, CookbookRecipe, EpubError, ExtractProgress, ExtractedRecipe,
-    ExtractionStats, Link, RecipeExtractor, Usage, assemble, build_chunk_request, cache,
-    chunk_epub, parse_recipes_payload, resolve_references, try_extract_chunk,
+    CallFailure, CallResult, Chunk, ChunkExtractionFailure, ChunkOutcome, CookbookRecipe,
+    EpubError, ExtractProgress, ExtractionStats, ModelTier, OrchestrationOptions, RecipeExtractor,
+    Usage, build_chunk_request, cache, chunk_epub, extract_chunks_with, parse_recipes_payload,
+    try_extract_chunk_detailed,
 };
 
 // ===========================================================================
@@ -75,8 +74,9 @@ pub async fn extract_cookbook(
 
 /// Like [`extract_cookbook`] but reports progress as each chunk completes. The
 /// sink is called once with `done == 0` when the chunk count is known, then once
-/// per finished chunk. It runs from the concurrent extraction tasks, so it must
-/// be `Send + Sync` (e.g. a closure writing to shared atomics).
+/// per finished chunk. The existing `Send + Sync` bound is retained for source
+/// compatibility even though the shared driver invokes it while consuming
+/// completions.
 pub async fn extract_cookbook_with_progress(
     bytes: &[u8],
     source: &str,
@@ -144,11 +144,9 @@ pub async fn extract_cookbook_with<E: RecipeExtractor>(
 /// Per-chunk diagnostics from [`debug_extract_cookbook`]: the RAW model tool
 /// `input` captured BEFORE `parse_recipes_payload`, plus the parse outcome.
 ///
-/// The debug counterpart to [`extract_cookbook`], which discards raw payloads
-/// and *silently skips* a chunk whose payload won't deserialize (see the
-/// `unwrap_or_else` in [`extract_cookbook_with_stats`]). Use this to see what the
-/// model actually emitted — e.g. a `null` where the recipe schema wants an array,
-/// which serde rejects with "invalid type: null, expected a sequence".
+/// The debug counterpart to [`extract_cookbook`], which returns assembled
+/// recipes and counts failed chunks. Use this to inspect the model's raw
+/// payload and parse error when extraction fails.
 #[derive(Debug, Clone)]
 pub struct ChunkDebug {
     /// The originating spine-doc path (labels the chunk).
@@ -224,7 +222,10 @@ pub async fn debug_extract_cookbook(
                             None => dbg.error = Some("model returned no tool block".to_string()),
                         }
                     }
-                    Err(e) => dbg.error = Some(format!("call failed: {e}")),
+                    Err(failure) => {
+                        dbg.truncated = failure.truncated;
+                        dbg.error = Some(format!("call failed: {}", failure.error));
+                    }
                 }
                 dbg
             }
@@ -248,107 +249,70 @@ async fn extract_cookbook_with_stats<E: RecipeExtractor>(
     let chunks = chunk_epub(bytes)?;
     let total = chunks.len();
     tracing::info!("epub {source}: {total} chunk(s)");
-    // Emit the initial snapshot now that the total is known, so the UI can switch
-    // from an indeterminate spinner to a determinate bar before any chunk lands.
-    progress(ExtractProgress {
-        done: 0,
-        total,
-        cached: 0,
-    });
-
-    // Book-wide internal anchor links (author hyperlinks between recipes) —
-    // the Layer 2 confirmation signal for cross-recipe references.
-    let links: Vec<Link> = chunks.iter().flat_map(|c| c.links.clone()).collect();
-
-    // Extract each chunk concurrently (bounded), preserving document order and
-    // each recipe's originating doc. A single failing chunk is logged and
-    // skipped rather than failing the whole book — but the skip is counted
-    // (`failed`) and surfaced via `ExtractionStats::chunks_failed`, so a
-    // caller can tell "the model found nothing here" from "this chunk's
-    // recipes were silently dropped". `done`/`cached`/`failed` are shared
-    // atomics so each completing task can emit a consistent, monotonic
-    // snapshot.
-    let done = AtomicUsize::new(0);
-    let cached = AtomicUsize::new(0);
-    let failed = AtomicUsize::new(0);
-    let per_chunk: Vec<(Chunk, ChunkOutcome)> = stream::iter(chunks.iter())
-        .map(|chunk| async {
-            let empty = || ChunkOutcome {
-                recipes: Vec::new(),
-                usage: Usage::default(),
-                cached: false,
-                truncated: false,
-            };
-            let outcome = match extractor.extract(chunk).await {
-                Ok(o) => o,
-                // Primary couldn't return a parseable payload (after its own
-                // in-call retry). Escalate this one chunk to the fallback model,
-                // then fall back to skip-and-salvage if that fails too.
-                Err(primary_err) => match escalation {
-                    Some(esc) => match esc.extract(chunk).await {
-                        Ok(o) => {
-                            tracing::info!(
-                                "chunk {} recovered by escalating to {}",
-                                chunk.doc_path,
-                                esc.model()
-                            );
-                            o
-                        }
-                        Err(esc_err) => {
-                            failed.fetch_add(1, Ordering::Relaxed);
-                            tracing::error!(
-                                "chunk {} failed on primary ({primary_err}) and escalation ({esc_err}); skipping — its recipes are lost",
-                                chunk.doc_path
-                            );
-                            empty()
-                        }
-                    },
-                    None => {
-                        failed.fetch_add(1, Ordering::Relaxed);
-                        tracing::error!(
-                            "chunk {} extraction failed: {primary_err}; skipping — its recipes are lost",
-                            chunk.doc_path
-                        );
-                        empty()
-                    }
+    let report = extract_chunks_with(
+        chunks,
+        source,
+        &OrchestrationOptions {
+            concurrency: opts.concurrency,
+            fallback: escalation.is_some(),
+            previews: false,
+        },
+        |_, chunk, tier| async move {
+            match tier {
+                ModelTier::Primary => extractor.extract_detailed(&chunk).await,
+                ModelTier::Fallback => match escalation {
+                    Some(fallback) => fallback.extract_detailed(&chunk).await,
+                    None => Err(EpubError::Proxy(
+                        "fallback tier requested without an escalation backend".to_string(),
+                    )
+                    .into()),
                 },
-            };
-            if outcome.cached {
-                cached.fetch_add(1, Ordering::Relaxed);
             }
-            let done_now = done.fetch_add(1, Ordering::Relaxed) + 1;
+        },
+        |snapshot| {
             progress(ExtractProgress {
-                done: done_now,
-                total,
-                cached: cached.load(Ordering::Relaxed),
+                done: snapshot.done,
+                total: snapshot.total,
+                cached: snapshot.cached,
             });
-            // Carry the whole chunk (its text lines + image positions) so the
-            // assembler can bind each recipe's hero photo by title proximity.
-            (chunk.clone(), outcome)
-        })
-        .buffered(opts.concurrency.max(1))
-        .collect::<Vec<_>>()
-        .await;
+        },
+    )
+    .await;
 
-    let mut stats = ExtractionStats {
+    for chunk in &report.chunks {
+        if chunk.tier == ModelTier::Fallback {
+            tracing::info!(
+                "chunk {} recovered by escalating to {}",
+                chunk.doc_path,
+                escalation.map_or("fallback", RecipeExtractor::model)
+            );
+        }
+    }
+    for failure in &report.failures {
+        if let Some(fallback) = &failure.fallback {
+            tracing::error!(
+                "chunk {} failed on primary ({}) and escalation ({}); skipping — its recipes are lost",
+                failure.doc_path,
+                failure.primary.message,
+                fallback.message
+            );
+        } else {
+            tracing::error!(
+                "chunk {} extraction failed: {}; skipping — its recipes are lost",
+                failure.doc_path,
+                failure.primary.message
+            );
+        }
+    }
+
+    let stats = ExtractionStats {
         model: extractor.model().to_string(),
-        chunks_total: per_chunk.len(),
-        chunks_failed: failed.load(Ordering::Relaxed),
-        ..Default::default()
+        chunks_total: report.chunks.len() + report.failures.len(),
+        chunks_cached: report.chunks_cached,
+        chunks_failed: report.failures.len(),
+        usage: report.usage,
     };
-    let recipes_by_chunk: Vec<(Chunk, Vec<ExtractedRecipe>)> = per_chunk
-        .into_iter()
-        .map(|(chunk, outcome)| {
-            if outcome.cached {
-                stats.chunks_cached += 1;
-            }
-            stats.usage.add(&outcome.usage);
-            (chunk, outcome.recipes)
-        })
-        .collect();
-
-    let mut recipes = assemble(recipes_by_chunk, source);
-    resolve_references(&mut recipes, &links);
+    let recipes = report.recipes;
     tracing::info!(
         "epub {source}: {} recipe(s); {}",
         recipes.len(),
@@ -370,6 +334,15 @@ impl<E: RecipeExtractor> RecipeExtractor for CachingExtractor<'_, E> {
     }
 
     async fn extract(&self, chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
+        self.extract_detailed(chunk)
+            .await
+            .map_err(|failure| failure.error)
+    }
+
+    async fn extract_detailed(
+        &self,
+        chunk: &Chunk,
+    ) -> Result<ChunkOutcome, ChunkExtractionFailure> {
         let key = cache::key(
             &self.model,
             &chunk.text,
@@ -384,7 +357,7 @@ impl<E: RecipeExtractor> RecipeExtractor for CachingExtractor<'_, E> {
                 truncated: false,
             });
         }
-        let outcome = self.inner.extract(chunk).await?;
+        let outcome = self.inner.extract_detailed(chunk).await?;
         // Never cache a truncated outcome: it would silently serve the partial
         // recipe list on every future run. Leaving it uncached lets a later run
         // (bigger limit, different model) re-attempt the chunk.
@@ -591,7 +564,7 @@ trait CallTool {
         &self,
         call: ToolCall<'_>,
         meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), EpubError>;
+    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure>;
 }
 
 /// Run one chunk through any [`CallTool`] backend: build the request, issue the
@@ -601,17 +574,17 @@ trait CallTool {
 /// `length`). Shared by both backends' [`RecipeExtractor::extract`].
 ///
 /// The call + parse + retry policy itself lives in the pure, wasm-shared
-/// [`try_extract_chunk`]; this just supplies the reqwest-backed `call` closure
+/// [`try_extract_chunk_detailed`]; this supplies the reqwest-backed `call` closure
 /// (which also tallies usage + truncation) and rewraps the result as a
 /// [`ChunkOutcome`]. The wasm driver shares the same policy with a JS-callback
 /// closure, so retry/parse behaviour can't drift between the two paths.
-async fn extract_chunk<T: CallTool>(
+async fn extract_chunk_detailed<T: CallTool>(
     backend: &T,
     chunk: &Chunk,
     truncated_reasons: &[&str],
-) -> Result<ChunkOutcome, EpubError> {
+) -> Result<ChunkOutcome, ChunkExtractionFailure> {
     let req = build_chunk_request(chunk);
-    let driven = try_extract_chunk(&chunk.doc_path, || async {
+    let driven = try_extract_chunk_detailed(&chunk.doc_path, || async {
         let (input, usage, reason) = backend
             .call_tool(
                 ToolCall {
@@ -683,7 +656,7 @@ impl CallTool for ClaudeExtractor {
         &self,
         call: ToolCall<'_>,
         meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), EpubError> {
+    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
         let body = json!({
             "model": self.conn.model,
             "max_tokens": call.max_tokens,
@@ -704,9 +677,15 @@ impl CallTool for ClaudeExtractor {
         });
 
         let extra = vec![("anthropic-version", ANTHROPIC_VERSION.to_string())];
-        let text = self.conn.post_tool(&body, extra, meta).await?;
+        let text = self
+            .conn
+            .post_tool(&body, extra, meta)
+            .await
+            .map_err(CallFailure::transport)?;
 
-        let parsed: ApiResponse = serde_json::from_str(&text)?;
+        let parsed: ApiResponse = serde_json::from_str(&text).map_err(|error| {
+            CallFailure::retryable_payload(error.into(), Usage::default(), false)
+        })?;
         let usage = parsed.usage;
         let stop_reason = parsed.stop_reason;
         // With forced tool_choice the response carries exactly one tool_use block.
@@ -724,7 +703,16 @@ impl RecipeExtractor for ClaudeExtractor {
     }
 
     async fn extract(&self, chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
-        extract_chunk(self, chunk, &["max_tokens"]).await
+        self.extract_detailed(chunk)
+            .await
+            .map_err(|failure| failure.error)
+    }
+
+    async fn extract_detailed(
+        &self,
+        chunk: &Chunk,
+    ) -> Result<ChunkOutcome, ChunkExtractionFailure> {
+        extract_chunk_detailed(self, chunk, &["max_tokens"]).await
     }
 }
 
@@ -800,7 +788,7 @@ impl CallTool for OpenAiExtractor {
         &self,
         call: ToolCall<'_>,
         meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), EpubError> {
+    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
         // OpenAI reasoning models (o1/o3/o4) and the gpt-5 family reject
         // `max_tokens` with a 400; they require `max_completion_tokens`.
         // Gemini's OpenAI-compat endpoint still takes `max_tokens`.
@@ -834,21 +822,13 @@ impl CallTool for OpenAiExtractor {
 
         // BYOK gateway: no provider-specific headers; the gateway injects the
         // provider's `Authorization: Bearer` key server-side.
-        let text = self.conn.post_tool(&body, Vec::new(), meta).await?;
+        let text = self
+            .conn
+            .post_tool(&body, Vec::new(), meta)
+            .await
+            .map_err(CallFailure::transport)?;
 
-        let parsed: OpenAiResponse = serde_json::from_str(&text)?;
-        let usage = parsed.usage.into();
-        let choice = parsed.choices.into_iter().next();
-        let finish_reason = choice.as_ref().and_then(|c| c.finish_reason.clone());
-        let args = choice
-            .and_then(|c| c.message.tool_calls)
-            .and_then(|calls| calls.into_iter().next())
-            .map(|call| call.function.arguments);
-        let input = match args {
-            Some(a) => Some(serde_json::from_str::<serde_json::Value>(&a)?),
-            None => None,
-        };
-        Ok((input, usage, finish_reason))
+        decode_openai_response(&text)
     }
 }
 
@@ -858,7 +838,16 @@ impl RecipeExtractor for OpenAiExtractor {
     }
 
     async fn extract(&self, chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
-        extract_chunk(self, chunk, &["length"]).await
+        self.extract_detailed(chunk)
+            .await
+            .map_err(|failure| failure.error)
+    }
+
+    async fn extract_detailed(
+        &self,
+        chunk: &Chunk,
+    ) -> Result<ChunkOutcome, ChunkExtractionFailure> {
+        extract_chunk_detailed(self, chunk, &["length"]).await
     }
 }
 
@@ -915,6 +904,32 @@ impl From<OpenAiUsage> for Usage {
     }
 }
 
+fn decode_openai_response(
+    text: &str,
+) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
+    let parsed: OpenAiResponse = serde_json::from_str(text)
+        .map_err(|error| CallFailure::retryable_payload(error.into(), Usage::default(), false))?;
+    let usage: Usage = parsed.usage.into();
+    let choice = parsed.choices.into_iter().next();
+    let finish_reason = choice
+        .as_ref()
+        .and_then(|choice| choice.finish_reason.clone());
+    let truncated = is_truncated(finish_reason.as_deref(), TRUNCATED_REASONS);
+    let arguments = choice
+        .and_then(|choice| choice.message.tool_calls)
+        .and_then(|calls| calls.into_iter().next())
+        .map(|call| call.function.arguments);
+    let input = match arguments {
+        Some(arguments) => Some(
+            serde_json::from_str::<serde_json::Value>(&arguments).map_err(|error| {
+                CallFailure::retryable_payload(error.into(), usage.clone(), truncated)
+            })?,
+        ),
+        None => None,
+    };
+    Ok((input, usage, finish_reason))
+}
+
 // ===========================================================================
 
 /// Runtime-selected extraction backend, chosen by model id.
@@ -958,7 +973,8 @@ impl Backend {
                     call: "classify",
                 },
             )
-            .await?;
+            .await
+            .map_err(|failure| failure.error)?;
         // A truncated index list silently mislabels the tail books as
         // non-cookbooks — at minimum, say so.
         if is_truncated(reason.as_deref(), TRUNCATED_REASONS) {
@@ -979,7 +995,7 @@ impl CallTool for Backend {
         &self,
         call: ToolCall<'_>,
         meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), EpubError> {
+    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
         match self {
             Backend::Claude(e) => e.call_tool(call, meta).await,
             Backend::OpenAi(e) => e.call_tool(call, meta).await,
@@ -1059,6 +1075,16 @@ impl RecipeExtractor for Backend {
         match self {
             Backend::Claude(e) => e.extract(chunk).await,
             Backend::OpenAi(e) => e.extract(chunk).await,
+        }
+    }
+
+    async fn extract_detailed(
+        &self,
+        chunk: &Chunk,
+    ) -> Result<ChunkOutcome, ChunkExtractionFailure> {
+        match self {
+            Backend::Claude(extractor) => extractor.extract_detailed(chunk).await,
+            Backend::OpenAi(extractor) => extractor.extract_detailed(chunk).await,
         }
     }
 }
@@ -1249,6 +1275,25 @@ mod tests {
             payload.recipes[0].sections[0].ingredients,
             vec!["1 cup flour", "2 eggs"]
         );
+    }
+
+    #[test]
+    fn malformed_openai_arguments_retain_usage_and_truncation() {
+        let raw = json!({
+            "choices": [{
+                "finish_reason": "length",
+                "message": {
+                    "tool_calls": [{ "function": { "arguments": "{not json" } }]
+                }
+            }],
+            "usage": { "prompt_tokens": 179, "completion_tokens": 45 }
+        })
+        .to_string();
+
+        let failure = decode_openai_response(&raw).unwrap_err();
+        assert_eq!(failure.usage.input_tokens, 179);
+        assert_eq!(failure.usage.output_tokens, 45);
+        assert!(failure.truncated);
     }
 
     /// Inner extractor that always fails, for [`chunks_failed`] accounting tests.

--- a/recipe-epub/src/backend.rs
+++ b/recipe-epub/src/backend.rs
@@ -137,7 +137,7 @@ pub async fn extract_cookbook_with<E: RecipeExtractor>(
     progress: impl Fn(ExtractProgress) + Send + Sync,
 ) -> Result<Vec<CookbookRecipe>, EpubError> {
     let (recipes, _stats) =
-        extract_cookbook_with_stats(bytes, source, opts, extractor, None, &progress).await?;
+        extract_cookbook_with_stats(bytes, source, opts, extractor, None::<&E>, &progress).await?;
     Ok(recipes)
 }
 
@@ -238,12 +238,12 @@ pub async fn debug_extract_cookbook(
 
 /// Like [`extract_cookbook_with`] but also returns token-usage/cost stats and
 /// reports per-chunk progress through `progress`.
-async fn extract_cookbook_with_stats<E: RecipeExtractor>(
+async fn extract_cookbook_with_stats<E: RecipeExtractor, F: RecipeExtractor>(
     bytes: &[u8],
     source: &str,
     opts: &Options,
     extractor: &E,
-    escalation: Option<&Backend>,
+    escalation: Option<&F>,
     progress: &(impl Fn(ExtractProgress) + Send + Sync),
 ) -> Result<(Vec<CookbookRecipe>, ExtractionStats), EpubError> {
     let chunks = chunk_epub(bytes)?;
@@ -553,6 +553,8 @@ fn warn_truncated(doc_path: &str) {
     tracing::warn!("chunk {doc_path} hit token limit; some recipes may be truncated");
 }
 
+type ToolResponse = Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure>;
+
 /// One forced-tool LLM call, abstracted over the provider wire format so callers
 /// (`extract`, `classify_cookbooks`) don't switch on the backend variant.
 #[allow(async_fn_in_trait)]
@@ -560,11 +562,7 @@ trait CallTool {
     /// Issue one forced-tool `call`, tagged for the gateway logs with `meta`.
     /// Returns the tool's decoded `input` object (`None` if the model returned no
     /// tool block), token usage, and the stop/finish reason.
-    async fn call_tool(
-        &self,
-        call: ToolCall<'_>,
-        meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure>;
+    async fn call_tool(&self, call: ToolCall<'_>, meta: &CallMeta<'_>) -> ToolResponse;
 }
 
 /// Run one chunk through any [`CallTool`] backend: build the request, issue the
@@ -652,11 +650,7 @@ impl CallTool for ClaudeExtractor {
     /// Issue one Anthropic Messages call with forced tool output. Returns the
     /// tool's `input` object (`None` if the model returned no tool block), the
     /// token usage, and the stop reason.
-    async fn call_tool(
-        &self,
-        call: ToolCall<'_>,
-        meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
+    async fn call_tool(&self, call: ToolCall<'_>, meta: &CallMeta<'_>) -> ToolResponse {
         let body = json!({
             "model": self.conn.model,
             "max_tokens": call.max_tokens,
@@ -784,11 +778,7 @@ impl CallTool for OpenAiExtractor {
     /// Issue one OpenAI-compatible chat-completions call with a forced function
     /// call. Returns the function's decoded arguments object (`None` if the model
     /// returned no tool call), token usage, and finish reason.
-    async fn call_tool(
-        &self,
-        call: ToolCall<'_>,
-        meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
+    async fn call_tool(&self, call: ToolCall<'_>, meta: &CallMeta<'_>) -> ToolResponse {
         // OpenAI reasoning models (o1/o3/o4) and the gpt-5 family reject
         // `max_tokens` with a 400; they require `max_completion_tokens`.
         // Gemini's OpenAI-compat endpoint still takes `max_tokens`.
@@ -904,9 +894,7 @@ impl From<OpenAiUsage> for Usage {
     }
 }
 
-fn decode_openai_response(
-    text: &str,
-) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
+fn decode_openai_response(text: &str) -> ToolResponse {
     let parsed: OpenAiResponse = serde_json::from_str(text)
         .map_err(|error| CallFailure::retryable_payload(error.into(), Usage::default(), false))?;
     let usage: Usage = parsed.usage.into();
@@ -991,11 +979,7 @@ impl Backend {
 }
 
 impl CallTool for Backend {
-    async fn call_tool(
-        &self,
-        call: ToolCall<'_>,
-        meta: &CallMeta<'_>,
-    ) -> Result<(Option<serde_json::Value>, Usage, Option<String>), CallFailure> {
+    async fn call_tool(&self, call: ToolCall<'_>, meta: &CallMeta<'_>) -> ToolResponse {
         match self {
             Backend::Claude(e) => e.call_tool(call, meta).await,
             Backend::OpenAi(e) => e.call_tool(call, meta).await,
@@ -1092,19 +1076,26 @@ impl RecipeExtractor for Backend {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::unwrap_used)]
+    use std::cell::RefCell;
+    use std::collections::VecDeque;
+
     use super::*;
     use crate::extractor::{RecipesPayload, TOOL_NAME};
 
     /// Inner extractor returning a fixed outcome, for cache-policy tests.
     struct FixedExtractor {
         truncated: bool,
+        input_tokens: u64,
     }
 
     impl RecipeExtractor for FixedExtractor {
         async fn extract(&self, _chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
             Ok(ChunkOutcome {
                 recipes: Vec::new(),
-                usage: Usage::default(),
+                usage: Usage {
+                    input_tokens: self.input_tokens,
+                    ..Usage::default()
+                },
                 cached: false,
                 truncated: self.truncated,
             })
@@ -1129,7 +1120,10 @@ mod tests {
             ));
             let _ = std::fs::remove_dir_all(&dir);
             let caching = CachingExtractor {
-                inner: &FixedExtractor { truncated },
+                inner: &FixedExtractor {
+                    truncated,
+                    input_tokens: 0,
+                },
                 dir: dir.clone(),
                 model: "test-model".to_string(),
             };
@@ -1255,20 +1249,12 @@ mod tests {
         })
         .to_string();
 
-        let parsed: OpenAiResponse = serde_json::from_str(&raw).unwrap();
-        let usage: Usage = parsed.usage.into();
+        let (input, usage, finish_reason) = decode_openai_response(&raw).unwrap();
         assert_eq!(usage.input_tokens, 179);
         assert_eq!(usage.output_tokens, 45);
+        assert_eq!(finish_reason.as_deref(), Some("tool_calls"));
 
-        let args = parsed
-            .choices
-            .into_iter()
-            .next()
-            .and_then(|c| c.message.tool_calls)
-            .and_then(|calls| calls.into_iter().next())
-            .map(|call| call.function.arguments)
-            .unwrap();
-        let payload: RecipesPayload = serde_json::from_str(&args).unwrap();
+        let payload: RecipesPayload = serde_json::from_value(input.unwrap()).unwrap();
         assert_eq!(payload.recipes.len(), 1);
         assert_eq!(payload.recipes[0].meta.title, "Pancakes");
         assert_eq!(
@@ -1296,6 +1282,86 @@ mod tests {
         assert!(failure.truncated);
     }
 
+    #[test]
+    fn malformed_openai_response_is_a_metadata_free_payload_failure() {
+        let failure = decode_openai_response("{").unwrap_err();
+        assert_eq!(failure.usage, Usage::default());
+        assert!(!failure.truncated);
+    }
+
+    struct ScriptedCallTool {
+        responses: RefCell<VecDeque<ToolResponse>>,
+    }
+
+    impl CallTool for ScriptedCallTool {
+        async fn call_tool(&self, call: ToolCall<'_>, meta: &CallMeta<'_>) -> ToolResponse {
+            assert_eq!(call.tool_name, TOOL_NAME);
+            assert_eq!(call.max_tokens, 16000);
+            assert_eq!(meta.call, "extract");
+            self.responses.borrow_mut().pop_front().unwrap()
+        }
+    }
+
+    fn extraction_chunk() -> Chunk {
+        Chunk {
+            title_hint: None,
+            text: "Pancakes\n1 cup flour\nMix.".to_string(),
+            doc_path: "chapter.xhtml".to_string(),
+            links: Vec::new(),
+            images: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn native_chunk_adapter_preserves_usage_and_truncation() {
+        let backend = ScriptedCallTool {
+            responses: RefCell::new(VecDeque::from([Ok((
+                Some(json!({
+                    "recipes": [{
+                        "title": "Pancakes",
+                        "sections": [{ "ingredients": ["1 cup flour"] }]
+                    }]
+                })),
+                Usage {
+                    input_tokens: 23,
+                    output_tokens: 7,
+                    ..Usage::default()
+                },
+                Some("length".to_string()),
+            ))])),
+        };
+
+        let outcome = extract_chunk_detailed(&backend, &extraction_chunk(), &["length"])
+            .await
+            .unwrap();
+        assert_eq!(outcome.recipes[0].meta.title, "Pancakes");
+        assert_eq!(outcome.usage.input_tokens, 23);
+        assert_eq!(outcome.usage.output_tokens, 7);
+        assert!(outcome.truncated);
+        assert!(!outcome.cached);
+    }
+
+    #[tokio::test]
+    async fn native_chunk_adapter_preserves_failed_call_metadata() {
+        let backend = ScriptedCallTool {
+            responses: RefCell::new(VecDeque::from([Err(CallFailure::transport_with_metadata(
+                EpubError::Proxy("offline".to_string()),
+                Usage {
+                    input_tokens: 13,
+                    ..Usage::default()
+                },
+                true,
+            ))])),
+        };
+
+        let failure = extract_chunk_detailed(&backend, &extraction_chunk(), &["length"])
+            .await
+            .unwrap_err();
+        assert_eq!(failure.usage.input_tokens, 13);
+        assert!(failure.truncated);
+        assert_eq!(failure.attempts.len(), 1);
+    }
+
     /// Inner extractor that always fails, for [`chunks_failed`] accounting tests.
     struct FailingExtractor;
 
@@ -1304,6 +1370,31 @@ mod tests {
             Err(EpubError::Api {
                 status: 500,
                 body: "boom".to_string(),
+            })
+        }
+    }
+
+    struct DetailedFailingExtractor {
+        input_tokens: u64,
+    }
+
+    impl RecipeExtractor for DetailedFailingExtractor {
+        async fn extract(&self, _chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
+            Err(EpubError::Proxy("failed".to_string()))
+        }
+
+        async fn extract_detailed(
+            &self,
+            _chunk: &Chunk,
+        ) -> Result<ChunkOutcome, ChunkExtractionFailure> {
+            Err(ChunkExtractionFailure {
+                error: EpubError::Proxy("failed".to_string()),
+                usage: Usage {
+                    input_tokens: self.input_tokens,
+                    ..Usage::default()
+                },
+                truncated: false,
+                attempts: Vec::new(),
             })
         }
     }
@@ -1391,7 +1482,7 @@ mod tests {
             "failing.epub",
             &Options::default(),
             &FailingExtractor,
-            None,
+            None::<&FailingExtractor>,
             &|_| {},
         )
         .await
@@ -1401,6 +1492,70 @@ mod tests {
         assert_eq!(stats.chunks_total, 1);
         assert_eq!(stats.chunks_failed, 1);
         assert!(stats.summary().contains("1 chunk(s) FAILED"));
+    }
+
+    #[tokio::test]
+    async fn native_driver_accounts_for_failed_primary_before_fallback_recovery() {
+        let bytes = minimal_epub();
+        let (recipes, stats) = extract_cookbook_with_stats(
+            &bytes,
+            "book.epub",
+            &Options::default(),
+            &DetailedFailingExtractor { input_tokens: 11 },
+            Some(&FixedExtractor {
+                truncated: false,
+                input_tokens: 17,
+            }),
+            &|_| {},
+        )
+        .await
+        .unwrap();
+
+        assert!(recipes.is_empty());
+        assert_eq!(stats.chunks_total, 1);
+        assert_eq!(stats.chunks_failed, 0);
+        assert_eq!(stats.usage.input_tokens, 28);
+    }
+
+    #[tokio::test]
+    async fn native_driver_salvages_book_when_both_tiers_fail() {
+        let bytes = minimal_epub();
+        let (recipes, stats) = extract_cookbook_with_stats(
+            &bytes,
+            "book.epub",
+            &Options::default(),
+            &DetailedFailingExtractor { input_tokens: 11 },
+            Some(&DetailedFailingExtractor { input_tokens: 17 }),
+            &|_| {},
+        )
+        .await
+        .unwrap();
+
+        assert!(recipes.is_empty());
+        assert_eq!(stats.chunks_total, 1);
+        assert_eq!(stats.chunks_failed, 1);
+        assert_eq!(stats.usage.input_tokens, 28);
+    }
+
+    #[tokio::test]
+    async fn cache_adapter_preserves_detailed_failure_metadata() {
+        let dir = std::env::temp_dir().join(format!(
+            "recipe-epub-failure-cache-test-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        let caching = CachingExtractor {
+            inner: &DetailedFailingExtractor { input_tokens: 19 },
+            dir: dir.clone(),
+            model: "test-model".to_string(),
+        };
+
+        let failure = caching
+            .extract_detailed(&extraction_chunk())
+            .await
+            .unwrap_err();
+        assert_eq!(failure.usage.input_tokens, 19);
+        assert!(!dir.exists());
     }
 
     #[test]

--- a/recipe-epub/src/extractor.rs
+++ b/recipe-epub/src/extractor.rs
@@ -92,6 +92,7 @@ impl Usage {
 }
 
 /// One chunk's extraction result plus its cost signal.
+#[derive(Debug, Clone)]
 pub struct ChunkOutcome {
     pub recipes: Vec<ExtractedRecipe>,
     /// Token usage for the API call. Zero when served from cache.
@@ -253,20 +254,205 @@ pub fn parse_recipes_payload(input: serde_json::Value) -> Result<Vec<ExtractedRe
 /// disjoint-failure escalation (a *different* model) is the caller's job.
 pub const PARSE_RETRIES: usize = 1;
 
-/// One model's structured output for a chunk: the raw tool `input` (`None` if the
-/// model returned no tool block) plus the cost/limit signals the native backend
-/// tracks. The wasm driver passes `Usage::default()` + `truncated: false`.
+/// One model call's structured output: the raw tool `input` (`None` if the model
+/// returned no tool block) plus caller-supplied cost/limit signals.
 pub struct CallResult {
     pub input: Option<serde_json::Value>,
     pub usage: Usage,
     pub truncated: bool,
 }
 
+/// A failed model call with any usage and truncation metadata the transport was
+/// still able to recover.
+///
+/// Use [`CallFailure::retryable_payload`] when a response arrived but its tool
+/// arguments were malformed. The shared driver retries those failures under the
+/// same policy as a decoded payload that fails [`parse_recipes_payload`].
+#[derive(Debug)]
+pub struct CallFailure {
+    pub error: EpubError,
+    pub usage: Usage,
+    pub truncated: bool,
+    retryable: bool,
+}
+
+impl CallFailure {
+    /// A transport/provider failure. It is not retried as a parse failure.
+    pub fn transport(error: EpubError) -> Self {
+        Self {
+            error,
+            usage: Usage::default(),
+            truncated: false,
+            retryable: false,
+        }
+    }
+
+    /// A transport/provider failure carrying metadata recovered from a response.
+    pub fn transport_with_metadata(error: EpubError, usage: Usage, truncated: bool) -> Self {
+        Self {
+            error,
+            usage,
+            truncated,
+            retryable: false,
+        }
+    }
+
+    /// Malformed structured output that can be retried with the same model.
+    pub fn retryable_payload(error: EpubError, usage: Usage, truncated: bool) -> Self {
+        Self {
+            error,
+            usage,
+            truncated,
+            retryable: true,
+        }
+    }
+}
+
+impl core::fmt::Display for CallFailure {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.error, formatter)
+    }
+}
+
+impl std::error::Error for CallFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+/// One failed call/parse attempt within a model tier.
+#[derive(Debug, Clone, Serialize)]
+pub struct FailedAttempt {
+    /// Zero-based call attempt within the tier.
+    pub attempt: usize,
+    pub message: String,
+    pub usage: Usage,
+    pub truncated: bool,
+}
+
+/// A model tier that could not produce a parseable chunk after its allowed
+/// attempts. Usage includes every attempt, successful HTTP response or not.
+#[derive(Debug)]
+pub struct ChunkExtractionFailure {
+    pub error: EpubError,
+    pub usage: Usage,
+    pub truncated: bool,
+    pub attempts: Vec<FailedAttempt>,
+}
+
+impl From<EpubError> for ChunkExtractionFailure {
+    fn from(error: EpubError) -> Self {
+        Self {
+            // The legacy interface exposes no attempt-level information.
+            attempts: Vec::new(),
+            error,
+            usage: Usage::default(),
+            truncated: false,
+        }
+    }
+}
+
+impl core::fmt::Display for ChunkExtractionFailure {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Display::fmt(&self.error, formatter)
+    }
+}
+
+impl std::error::Error for ChunkExtractionFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
 /// Recipes decoded from one model for one chunk, with accumulated usage.
+#[derive(Debug, Clone)]
 pub struct DrivenChunk {
     pub recipes: Vec<ExtractedRecipe>,
     pub usage: Usage,
     pub truncated: bool,
+}
+
+/// Detailed form of [`try_extract_chunk`] for transports that can report usage
+/// and truncation even when the call itself fails.
+pub async fn try_extract_chunk_detailed<F, Fut>(
+    doc_path: &str,
+    call: F,
+) -> Result<DrivenChunk, ChunkExtractionFailure>
+where
+    F: Fn() -> Fut,
+    Fut: core::future::Future<Output = Result<CallResult, CallFailure>>,
+{
+    let mut usage = Usage::default();
+    let mut attempts = Vec::new();
+    let mut attempt = 0;
+    loop {
+        let result = match call().await {
+            Ok(result) => result,
+            Err(failure) => {
+                usage.add(&failure.usage);
+                let failed = FailedAttempt {
+                    attempt,
+                    message: failure.error.to_string(),
+                    usage: failure.usage,
+                    truncated: failure.truncated,
+                };
+                let can_retry = failure.retryable && !failure.truncated && attempt < PARSE_RETRIES;
+                attempts.push(failed);
+                if can_retry {
+                    tracing::warn!(
+                        "chunk {doc_path} payload didn't decode ({}); retrying",
+                        failure.error
+                    );
+                    attempt += 1;
+                    continue;
+                }
+                return Err(ChunkExtractionFailure {
+                    error: failure.error,
+                    usage,
+                    truncated: failure.truncated,
+                    attempts,
+                });
+            }
+        };
+        usage.add(&result.usage);
+        match result.input {
+            // No tool block / no recipes is a valid empty result, not a failure.
+            None => {
+                return Ok(DrivenChunk {
+                    recipes: Vec::new(),
+                    usage,
+                    truncated: result.truncated,
+                });
+            }
+            Some(input) => match parse_recipes_payload(input) {
+                Ok(recipes) => {
+                    return Ok(DrivenChunk {
+                        recipes,
+                        usage,
+                        truncated: result.truncated,
+                    });
+                }
+                Err(error) => {
+                    attempts.push(FailedAttempt {
+                        attempt,
+                        message: error.to_string(),
+                        usage: result.usage,
+                        truncated: result.truncated,
+                    });
+                    if result.truncated || attempt >= PARSE_RETRIES {
+                        return Err(ChunkExtractionFailure {
+                            error,
+                            usage,
+                            truncated: result.truncated,
+                            attempts,
+                        });
+                    }
+                    tracing::warn!("chunk {doc_path} payload didn't parse ({error}); retrying");
+                    attempt += 1;
+                }
+            },
+        }
+    }
 }
 
 /// Drive ONE model over one chunk: call it, decode the payload, and retry the
@@ -283,40 +469,11 @@ where
     F: Fn() -> Fut,
     Fut: core::future::Future<Output = Result<CallResult, EpubError>>,
 {
-    let mut usage = Usage::default();
-    let mut attempt = 0;
-    loop {
-        let CallResult {
-            input,
-            usage: call_usage,
-            truncated,
-        } = call().await?;
-        usage.add(&call_usage);
-        match input {
-            // No tool block / no recipes is a valid empty result, not a failure.
-            None => {
-                return Ok(DrivenChunk {
-                    recipes: Vec::new(),
-                    usage,
-                    truncated,
-                });
-            }
-            Some(v) => match parse_recipes_payload(v) {
-                Ok(recipes) => {
-                    return Ok(DrivenChunk {
-                        recipes,
-                        usage,
-                        truncated,
-                    });
-                }
-                Err(e) if truncated || attempt >= PARSE_RETRIES => return Err(e),
-                Err(e) => {
-                    tracing::warn!("chunk {doc_path} payload didn't parse ({e}); retrying");
-                    attempt += 1;
-                }
-            },
-        }
-    }
+    try_extract_chunk_detailed(doc_path, || async {
+        call().await.map_err(CallFailure::transport)
+    })
+    .await
+    .map_err(|failure| failure.error)
 }
 
 /// Turns a [`Chunk`] of cookbook text into zero or more recipes.
@@ -327,6 +484,18 @@ where
 #[allow(async_fn_in_trait)]
 pub trait RecipeExtractor {
     async fn extract(&self, chunk: &Chunk) -> Result<ChunkOutcome, EpubError>;
+
+    /// Detailed adapter used by whole-book orchestration. Existing implementations
+    /// remain source-compatible; their legacy error type cannot report usage or
+    /// truncation that was lost before returning `Err`.
+    async fn extract_detailed(
+        &self,
+        chunk: &Chunk,
+    ) -> Result<ChunkOutcome, ChunkExtractionFailure> {
+        self.extract(chunk)
+            .await
+            .map_err(ChunkExtractionFailure::from)
+    }
 
     /// Model id for cost attribution; empty when not applicable (e.g. the mock).
     fn model(&self) -> &str {

--- a/recipe-epub/src/extractor.rs
+++ b/recipe-epub/src/extractor.rs
@@ -793,7 +793,7 @@ mod tests {
 
     use std::cell::Cell;
 
-    use super::{CallResult, Usage, try_extract_chunk};
+    use super::{CallFailure, CallResult, Usage, try_extract_chunk, try_extract_chunk_detailed};
 
     fn call_result(input: serde_json::Value, truncated: bool) -> CallResult {
         CallResult {
@@ -801,6 +801,72 @@ mod tests {
             usage: Usage::default(),
             truncated,
         }
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    #[tokio::test]
+    async fn absent_tool_output_is_empty_success_with_metadata(#[case] truncated: bool) {
+        let calls = Cell::new(0);
+        let usage = Usage {
+            input_tokens: 10,
+            output_tokens: 4,
+            cache_creation_input_tokens: 3,
+            cache_read_input_tokens: 2,
+        };
+        let driven = try_extract_chunk_detailed("empty.xhtml", || {
+            calls.set(calls.get() + 1);
+            let usage = usage.clone();
+            async move {
+                Ok(CallResult {
+                    input: None,
+                    usage,
+                    truncated,
+                })
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(calls.get(), 1);
+        assert!(driven.recipes.is_empty());
+        assert_eq!(driven.usage, usage);
+        assert_eq!(driven.truncated, truncated);
+    }
+
+    #[tokio::test]
+    async fn truncated_raw_payload_error_preserves_its_source_without_retry() {
+        use std::error::Error;
+
+        let calls = Cell::new(0);
+        let failure = try_extract_chunk_detailed("cut.xhtml", || {
+            calls.set(calls.get() + 1);
+            async {
+                let error = serde_json::from_str::<serde_json::Value>("{").unwrap_err();
+                let failed_call = CallFailure::retryable_payload(
+                    error.into(),
+                    Usage {
+                        output_tokens: 16_000,
+                        ..Default::default()
+                    },
+                    true,
+                );
+                assert_eq!(
+                    failed_call.to_string(),
+                    failed_call.source().unwrap().to_string()
+                );
+                Err(failed_call)
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(failure.usage.output_tokens, 16_000);
+        assert!(failure.truncated);
+        assert_eq!(failure.attempts.len(), 1);
+        assert_eq!(failure.to_string(), failure.source().unwrap().to_string());
+        assert!(failure.to_string().contains("EOF"));
     }
 
     #[tokio::test]

--- a/recipe-epub/src/lib.rs
+++ b/recipe-epub/src/lib.rs
@@ -8,32 +8,40 @@
 //! *strings* come back verbatim; [`CookbookRecipe::parse`] runs the core
 //! `ingredient` nom parser over them. The LLM never parses quantities.
 //!
-//! Entry point: [`extract_cookbook`] (selects a backend from `Options.model`) or
-//! [`extract_cookbook_with`] (any [`RecipeExtractor`], e.g. a mock in tests).
+//! [`extract_chunks_with`] drives a book using caller-supplied transport on
+//! native or browser runtimes. With the `native` feature, `extract_cookbook`
+//! selects a configured backend and `extract_cookbook_with` accepts any
+//! [`RecipeExtractor`], including mocks.
 
 // `backend`, `cache`, and `library` are native-only — each gates itself with an
 // inner `#![cfg(feature = "native")]`, so their `mod` lines stay unconditional
-// here. `epub_text` + `extractor` are the pure contract, compiled everywhere.
+// here. The other modules form the runtime-independent contract.
 mod backend;
 mod cache;
 mod epub_text;
 mod extractor;
 mod library;
+mod orchestration;
 
 // Pure extraction API — compiles to wasm32: EPUB unzip + text chunking
 // (`chunk_epub`), per-chunk request building (`build_chunk_request`), LLM
-// response parsing (`parse_recipes_payload`), and assembly (`assemble_recipes`).
+// response parsing (`parse_recipes_payload`), whole-book scheduling
+// (`extract_chunks_with`), and assembly (`assemble_recipes`).
 //
-// NOTHING IN THIS REPO CALLS THESE. They exist for cubby's recipebridge, which
-// builds this crate with `default-features = false` and drives extraction in
-// the browser; a repo-local caller search will say they are dead (see
-// CONTRIBUTING.md). CI keeps them honest with
-// `cargo check -p recipe-epub --no-default-features`.
+// These APIs support external browser callers with `default-features = false`;
+// preserve downstream compatibility even when an API has no in-tree caller.
+// CI tests the non-native library and compiles the browser callback example
+// for wasm32.
 pub use epub_text::chunk_epub;
 pub use extractor::{
-    CallResult, ChunkOutcome, ChunkRequest, DrivenChunk, ExtractedRecipe, MockExtractor, MockMatch,
-    PARSE_RETRIES, RecipeExtractor, RecipeMeta, Usage, build_chunk_request, parse_recipes_payload,
-    recipes_tool_schema, try_extract_chunk,
+    CallFailure, CallResult, ChunkExtractionFailure, ChunkOutcome, ChunkRequest, DrivenChunk,
+    ExtractedRecipe, FailedAttempt, MockExtractor, MockMatch, PARSE_RETRIES, RecipeExtractor,
+    RecipeMeta, Usage, build_chunk_request, parse_recipes_payload, recipes_tool_schema,
+    try_extract_chunk, try_extract_chunk_detailed,
+};
+pub use orchestration::{
+    ChunkFailure, ChunkReport, ChunkTruncation, ExtractionProgress, ExtractionReport, ModelTier,
+    OrchestrationOptions, TierFailure, extract_chunks_with,
 };
 // Library scanning: list + classify the cookbooks in a directory of epubs
 // (native: needs std::fs + the LLM classifier).
@@ -42,9 +50,8 @@ pub use library::{
     BookMeta, CookbookGuess, book_cover, book_metadata, classify_by_tags, classify_cookbooks_ai,
     find_epubs,
 };
-// The native extraction orchestration (backends + cache + async) lives in
-// `backend`; re-export the public entry points so `recipe_epub::extract_cookbook`
-// (etc.) paths stay stable.
+// Native entrypoints configure backends and caching, then use the shared driver.
+// Keep their existing crate-root paths stable.
 #[cfg(feature = "native")]
 pub use backend::{
     ChunkDebug, Options, debug_extract_cookbook, extract_cookbook, extract_cookbook_with,
@@ -192,8 +199,8 @@ impl CookbookRecipeExt for CookbookRecipe {
 
 /// Progress snapshot emitted during [`extract_cookbook_with_progress`]: how many
 /// chunks have finished extracting (`done`) out of `total`, and how many of those
-/// came from the on-disk cache (`cached`). Each snapshot is internally consistent
-/// (the counts come from monotonic atomic increments).
+/// came from the on-disk cache (`cached`). Counts are monotonic and internally
+/// consistent.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ExtractProgress {
     /// Chunks finished so far.
@@ -295,7 +302,7 @@ fn price_per_mtok(model: &str) -> Option<(f64, f64)> {
 /// Assemble per-chunk extractor output into final recipes and resolve
 /// cross-recipe references — the pure post-LLM stage, no I/O.
 ///
-/// `per_chunk` is `(doc_path, recipes)` in spine reading order (one entry per
+/// `per_chunk` is `(Chunk, recipes)` in spine reading order (one entry per
 /// chunk); `links` is the book-wide set of internal anchor links (the Layer-2
 /// reference-confirmation signal, gathered from every chunk). This is the wasm
 /// boundary's counterpart to [`chunk_epub`]: the browser runs the LLM per chunk,
@@ -318,7 +325,7 @@ pub fn assemble_recipes(
 /// into the first (sections, instructions, and notes are unioned) rather than
 /// dropped. This recovers the recipe's tail (extra steps, "Do Ahead" notes)
 /// instead of discarding it. For the common single-chunk recipe it's a no-op.
-/// `pub(crate)` so the native orchestration in [`crate::backend`] can call it.
+/// Used by [`assemble_recipes`] after the driver restores input order.
 pub(crate) fn assemble(
     per_chunk: Vec<(Chunk, Vec<ExtractedRecipe>)>,
     source: &str,

--- a/recipe-epub/src/orchestration.rs
+++ b/recipe-epub/src/orchestration.rs
@@ -795,6 +795,44 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn failed_primary_truncation_survives_report_serialization() {
+        let progress = RefCell::new(Vec::new());
+        let report = extract_chunks_with(
+            vec![chunk("cut.xhtml", "Incomplete recipe")],
+            "book.epub",
+            &OrchestrationOptions {
+                previews: true,
+                ..Default::default()
+            },
+            |_, _, _| async { Err(failure("token limit", 16_000, true)) },
+            |snapshot| progress.borrow_mut().push(snapshot),
+        )
+        .await;
+
+        let serialized = serde_json::to_value(&report).unwrap();
+        assert_eq!(serialized["failures"][0]["index"], 0);
+        assert_eq!(serialized["failures"][0]["doc_path"], "cut.xhtml");
+        assert_eq!(
+            serialized["failures"][0]["primary"]["message"],
+            "chunk extraction call failed: token limit"
+        );
+        assert_eq!(serialized["truncations"][0]["tier"], "primary");
+        assert_eq!(report.usage.input_tokens, 16_000);
+        let progress = progress.borrow();
+        assert_eq!(progress.last().unwrap().failed, 1);
+        assert_eq!(progress.last().unwrap().done, 1);
+        assert!(
+            progress
+                .last()
+                .unwrap()
+                .preview
+                .as_ref()
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn detailed_retry_keeps_usage_from_retryable_call_failures() {
         let calls = Cell::new(0);
         let result = try_extract_chunk_detailed("doc", || {

--- a/recipe-epub/src/orchestration.rs
+++ b/recipe-epub/src/orchestration.rs
@@ -1,0 +1,872 @@
+//! Runtime-independent whole-book extraction orchestration.
+//!
+//! Callers provide the extraction transport; this module owns bounded scheduling,
+//! model escalation, failure salvage, stable ordering, progress previews, usage
+//! accounting, and final assembly. It deliberately has no HTTP, filesystem,
+//! cache, Tokio, or browser dependencies.
+
+use futures::stream::{self, StreamExt};
+use serde::Serialize;
+
+use crate::{
+    Chunk, ChunkExtractionFailure, ChunkOutcome, CookbookRecipe, ExtractedRecipe, Usage,
+    assemble_recipes,
+};
+
+/// Which caller-provided extraction transport to use for a chunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ModelTier {
+    Primary,
+    Fallback,
+}
+
+/// Whole-book scheduling and reporting options.
+#[derive(Debug, Clone)]
+pub struct OrchestrationOptions {
+    /// Maximum number of chunks extracting concurrently. Zero is treated as one.
+    pub concurrency: usize,
+    /// Whether a failed primary extraction should be retried through the fallback tier.
+    pub fallback: bool,
+    /// Whether progress snapshots should include assembled recipe previews.
+    pub previews: bool,
+}
+
+impl Default for OrchestrationOptions {
+    fn default() -> Self {
+        Self {
+            concurrency: 8,
+            fallback: false,
+            previews: false,
+        }
+    }
+}
+
+/// One tier's terminal failure, including all usage and truncation signals known
+/// to the transport and parser retry driver.
+#[derive(Debug, Clone, Serialize)]
+pub struct TierFailure {
+    pub message: String,
+    pub usage: Usage,
+    pub truncated: bool,
+    pub attempts: Vec<crate::FailedAttempt>,
+}
+
+impl From<ChunkExtractionFailure> for TierFailure {
+    fn from(failure: ChunkExtractionFailure) -> Self {
+        Self {
+            message: failure.error.to_string(),
+            usage: failure.usage,
+            truncated: failure.truncated,
+            attempts: failure.attempts,
+        }
+    }
+}
+
+/// A chunk lost after its primary and optional fallback tiers failed.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChunkFailure {
+    pub index: usize,
+    pub doc_path: String,
+    pub primary: TierFailure,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fallback: Option<TierFailure>,
+}
+
+/// Ordered extraction information for a successful chunk.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChunkReport {
+    pub index: usize,
+    pub doc_path: String,
+    pub tier: ModelTier,
+    pub recipes: Vec<ExtractedRecipe>,
+    /// Usage across the successful tier plus a failed primary tier, if escalation occurred.
+    pub usage: Usage,
+    /// Usage from the tier that produced `recipes` (zero for a cache hit).
+    pub tier_usage: Usage,
+    pub cached: bool,
+    pub truncated: bool,
+    /// Present when the fallback tier recovered a primary failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primary_failure: Option<TierFailure>,
+}
+
+/// A progress snapshot emitted initially and after each completed chunk.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractionProgress {
+    pub done: usize,
+    pub total: usize,
+    pub cached: usize,
+    pub failed: usize,
+    /// Recipes assembled from the chunks completed so far, in original book order.
+    /// A continuation that completes before its head may appear only in a later preview.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preview: Option<Vec<CookbookRecipe>>,
+}
+
+/// Complete whole-book extraction result.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractionReport {
+    pub recipes: Vec<CookbookRecipe>,
+    /// Successful chunks in original input order.
+    pub chunks: Vec<ChunkReport>,
+    /// Failed chunks in original input order.
+    pub failures: Vec<ChunkFailure>,
+    /// Usage from every reported call, including failed attempts and fallback calls.
+    pub usage: Usage,
+    pub primary_usage: Usage,
+    pub fallback_usage: Usage,
+    pub chunks_cached: usize,
+    /// Successful or failed tiers that reported token-limit truncation.
+    pub truncations: Vec<ChunkTruncation>,
+}
+
+/// A tier that reported token-limit truncation.
+#[derive(Debug, Clone, Serialize)]
+pub struct ChunkTruncation {
+    pub index: usize,
+    pub doc_path: String,
+    pub tier: ModelTier,
+}
+
+struct CompletedChunk {
+    chunk: Chunk,
+    report: Result<ChunkReport, ChunkFailure>,
+}
+
+/// Extract and assemble a complete book using caller-provided transports.
+///
+/// `extract(index, chunk, tier)` receives an owned, complete [`Chunk`] on each
+/// invocation, which makes ordinary async closures (including browser closures
+/// with non-`Send` futures) straightforward. The callback should drive exactly
+/// one model tier, normally with [`crate::try_extract_chunk_detailed`] when it
+/// starts from raw model responses.
+///
+/// Chunks execute concurrently and may finish in any order. Reports, previews,
+/// and final assembly always use their original input order.
+pub async fn extract_chunks_with<F, Fut, P>(
+    chunks: Vec<Chunk>,
+    source: &str,
+    options: &OrchestrationOptions,
+    extract: F,
+    progress: P,
+) -> ExtractionReport
+where
+    F: Fn(usize, Chunk, ModelTier) -> Fut,
+    Fut: core::future::Future<Output = Result<ChunkOutcome, ChunkExtractionFailure>>,
+    P: Fn(ExtractionProgress),
+{
+    let total = chunks.len();
+    let links: Vec<crate::Link> = chunks
+        .iter()
+        .flat_map(|chunk| chunk.links.clone())
+        .collect();
+    progress(ExtractionProgress {
+        done: 0,
+        total,
+        cached: 0,
+        failed: 0,
+        preview: options.previews.then(Vec::new),
+    });
+
+    let mut stream = stream::iter(chunks.into_iter().enumerate().map(|(index, chunk)| {
+        let extract = &extract;
+        async move {
+            let primary = extract(index, chunk.clone(), ModelTier::Primary).await;
+            let report = match primary {
+                Ok(outcome) => Ok(success_report(
+                    index,
+                    &chunk.doc_path,
+                    ModelTier::Primary,
+                    outcome,
+                    None,
+                )),
+                Err(primary) if options.fallback => {
+                    let primary = TierFailure::from(primary);
+                    match extract(index, chunk.clone(), ModelTier::Fallback).await {
+                        Ok(outcome) => Ok(success_report(
+                            index,
+                            &chunk.doc_path,
+                            ModelTier::Fallback,
+                            outcome,
+                            Some(primary),
+                        )),
+                        Err(fallback) => Err(ChunkFailure {
+                            index,
+                            doc_path: chunk.doc_path.clone(),
+                            primary,
+                            fallback: Some(fallback.into()),
+                        }),
+                    }
+                }
+                Err(primary) => Err(ChunkFailure {
+                    index,
+                    doc_path: chunk.doc_path.clone(),
+                    primary: primary.into(),
+                    fallback: None,
+                }),
+            };
+            (index, CompletedChunk { chunk, report })
+        }
+    }))
+    .buffer_unordered(options.concurrency.max(1));
+
+    let mut completed: Vec<Option<CompletedChunk>> =
+        core::iter::repeat_with(|| None).take(total).collect();
+    let mut done = 0;
+    let mut cached = 0;
+    let mut failed = 0;
+    while let Some((index, result)) = stream.next().await {
+        match &result.report {
+            Ok(report) => cached += usize::from(report.cached),
+            Err(_) => failed += 1,
+        }
+        completed[index] = Some(result);
+        done += 1;
+        if done < total {
+            let preview = options
+                .previews
+                .then(|| assemble_completed(&completed, &links, source));
+            progress(ExtractionProgress {
+                done,
+                total,
+                cached,
+                failed,
+                preview,
+            });
+        }
+    }
+
+    let report = build_report(completed, links, source);
+    if total > 0 {
+        progress(ExtractionProgress {
+            done,
+            total,
+            cached,
+            failed,
+            preview: options.previews.then(|| report.recipes.clone()),
+        });
+    }
+    report
+}
+
+fn success_report(
+    index: usize,
+    doc_path: &str,
+    tier: ModelTier,
+    outcome: ChunkOutcome,
+    primary_failure: Option<TierFailure>,
+) -> ChunkReport {
+    let tier_usage = outcome.usage;
+    let mut usage = tier_usage.clone();
+    if let Some(failure) = &primary_failure {
+        usage.add(&failure.usage);
+    }
+    ChunkReport {
+        index,
+        doc_path: doc_path.to_string(),
+        tier,
+        recipes: outcome.recipes,
+        usage,
+        tier_usage,
+        cached: outcome.cached,
+        truncated: outcome.truncated,
+        primary_failure,
+    }
+}
+
+fn assemble_completed(
+    completed: &[Option<CompletedChunk>],
+    links: &[crate::Link],
+    source: &str,
+) -> Vec<CookbookRecipe> {
+    let per_chunk = completed
+        .iter()
+        .flatten()
+        .filter_map(|item| match &item.report {
+            Ok(report) => Some((item.chunk.clone(), report.recipes.clone())),
+            Err(_) => None,
+        })
+        .collect();
+    assemble_recipes(per_chunk, links.to_vec(), source)
+}
+
+fn build_report(
+    completed: Vec<Option<CompletedChunk>>,
+    links: Vec<crate::Link>,
+    source: &str,
+) -> ExtractionReport {
+    let recipes = assemble_completed(&completed, &links, source);
+    let mut chunks = Vec::new();
+    let mut failures = Vec::new();
+    let mut usage = Usage::default();
+    let mut primary_usage = Usage::default();
+    let mut fallback_usage = Usage::default();
+    let mut chunks_cached = 0;
+    let mut truncations = Vec::new();
+
+    for completed in completed.into_iter().flatten() {
+        match completed.report {
+            Ok(report) => {
+                usage.add(&report.usage);
+                match report.tier {
+                    ModelTier::Primary => primary_usage.add(&report.usage),
+                    ModelTier::Fallback => {
+                        if let Some(primary) = &report.primary_failure {
+                            primary_usage.add(&primary.usage);
+                            fallback_usage.add(&report.tier_usage);
+                            if primary.truncated {
+                                truncations.push(ChunkTruncation {
+                                    index: report.index,
+                                    doc_path: report.doc_path.clone(),
+                                    tier: ModelTier::Primary,
+                                });
+                            }
+                        }
+                    }
+                }
+                if report.truncated {
+                    truncations.push(ChunkTruncation {
+                        index: report.index,
+                        doc_path: report.doc_path.clone(),
+                        tier: report.tier,
+                    });
+                }
+                chunks_cached += usize::from(report.cached);
+                chunks.push(report);
+            }
+            Err(failure) => {
+                usage.add(&failure.primary.usage);
+                primary_usage.add(&failure.primary.usage);
+                if failure.primary.truncated {
+                    truncations.push(ChunkTruncation {
+                        index: failure.index,
+                        doc_path: failure.doc_path.clone(),
+                        tier: ModelTier::Primary,
+                    });
+                }
+                if let Some(fallback) = &failure.fallback {
+                    usage.add(&fallback.usage);
+                    fallback_usage.add(&fallback.usage);
+                    if fallback.truncated {
+                        truncations.push(ChunkTruncation {
+                            index: failure.index,
+                            doc_path: failure.doc_path.clone(),
+                            tier: ModelTier::Fallback,
+                        });
+                    }
+                }
+                failures.push(failure);
+            }
+        }
+    }
+
+    ExtractionReport {
+        recipes,
+        chunks,
+        failures,
+        usage,
+        primary_usage,
+        fallback_usage,
+        chunks_cached,
+        truncations,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+    use std::task::Poll;
+
+    use futures::future::poll_fn;
+    use recipe_scraper::RecipeSection;
+
+    use super::*;
+    use crate::{
+        CallFailure, CallResult, EpubError, ImageRef, RecipeMeta, try_extract_chunk_detailed,
+    };
+
+    fn chunk(path: &str, text: &str) -> Chunk {
+        Chunk {
+            title_hint: None,
+            text: text.to_string(),
+            doc_path: path.to_string(),
+            links: Vec::new(),
+            images: Vec::new(),
+        }
+    }
+
+    fn recipe(title: &str, ingredient: Option<&str>) -> ExtractedRecipe {
+        ExtractedRecipe {
+            meta: RecipeMeta {
+                title: title.to_string(),
+                ..Default::default()
+            },
+            sections: vec![RecipeSection {
+                name: None,
+                ingredients: ingredient.into_iter().map(str::to_string).collect(),
+                instructions: vec!["Cook.".to_string()],
+            }],
+        }
+    }
+
+    fn outcome(recipes: Vec<ExtractedRecipe>, tokens: u64) -> ChunkOutcome {
+        ChunkOutcome {
+            recipes,
+            usage: Usage {
+                input_tokens: tokens,
+                ..Default::default()
+            },
+            cached: false,
+            truncated: false,
+        }
+    }
+
+    fn failure(message: &str, tokens: u64, truncated: bool) -> ChunkExtractionFailure {
+        let usage = Usage {
+            input_tokens: tokens,
+            ..Default::default()
+        };
+        ChunkExtractionFailure {
+            error: EpubError::Proxy(message.to_string()),
+            usage: usage.clone(),
+            truncated,
+            attempts: vec![crate::FailedAttempt {
+                attempt: 0,
+                message: message.to_string(),
+                usage,
+                truncated,
+            }],
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn completion_order_does_not_change_reports_or_assembly() {
+        let delayed_once = Rc::new(Cell::new(false));
+        let progress = Rc::new(RefCell::new(Vec::new()));
+        let progress_sink = Rc::clone(&progress);
+        let report = extract_chunks_with(
+            vec![chunk("a.xhtml", "Alpha"), chunk("b.xhtml", "Beta")],
+            "book.epub",
+            &OrchestrationOptions {
+                concurrency: 2,
+                previews: true,
+                ..Default::default()
+            },
+            move |index, _, _| {
+                let delayed_once = Rc::clone(&delayed_once);
+                async move {
+                    if index == 0 {
+                        poll_fn(move |cx| {
+                            if delayed_once.replace(true) {
+                                Poll::Ready(())
+                            } else {
+                                cx.waker().wake_by_ref();
+                                Poll::Pending
+                            }
+                        })
+                        .await;
+                    }
+                    let title = if index == 0 { "Alpha" } else { "Beta" };
+                    Ok(outcome(
+                        vec![recipe(title, Some("1 item"))],
+                        index as u64 + 1,
+                    ))
+                }
+            },
+            move |snapshot| progress_sink.borrow_mut().push(snapshot),
+        )
+        .await;
+
+        assert_eq!(
+            report
+                .recipes
+                .iter()
+                .map(|recipe| recipe.meta.title.as_str())
+                .collect::<Vec<_>>(),
+            ["Alpha", "Beta"]
+        );
+        assert_eq!(
+            report
+                .chunks
+                .iter()
+                .map(|chunk| chunk.index)
+                .collect::<Vec<_>>(),
+            [0, 1]
+        );
+        let snapshots = progress.borrow();
+        assert_eq!(snapshots.len(), 3);
+        assert_eq!(snapshots[0].done, 0);
+        assert_eq!(snapshots[1].done, 1);
+        assert_eq!(snapshots[1].preview.as_ref().unwrap()[0].meta.title, "Beta");
+        assert_eq!(snapshots[2].preview.as_ref().unwrap(), &report.recipes);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fallback_salvages_partial_book_and_accounts_for_every_tier() {
+        let report = extract_chunks_with(
+            vec![chunk("a.xhtml", "A"), chunk("b.xhtml", "B")],
+            "book.epub",
+            &OrchestrationOptions {
+                fallback: true,
+                ..Default::default()
+            },
+            |index, _, tier| async move {
+                match (index, tier) {
+                    (0, ModelTier::Primary) => Err(failure("primary malformed", 10, true)),
+                    (0, ModelTier::Fallback) => Ok(outcome(vec![recipe("A", Some("a"))], 20)),
+                    (1, ModelTier::Primary) => Err(failure("primary failed", 30, false)),
+                    (1, ModelTier::Fallback) => Err(failure("fallback failed", 40, true)),
+                    _ => Ok(outcome(Vec::new(), 0)),
+                }
+            },
+            |_| {},
+        )
+        .await;
+
+        assert_eq!(report.recipes.len(), 1);
+        assert_eq!(report.chunks.len(), 1);
+        assert_eq!(report.failures.len(), 1);
+        assert_eq!(report.usage.input_tokens, 100);
+        assert_eq!(report.primary_usage.input_tokens, 40);
+        assert_eq!(report.fallback_usage.input_tokens, 60);
+        assert_eq!(report.truncations.len(), 2);
+        assert_eq!(report.chunks[0].usage.input_tokens, 30);
+        assert!(report.chunks[0].primary_failure.is_some());
+        assert_eq!(report.failures[0].index, 1);
+        assert_eq!(
+            report.failures[0]
+                .fallback
+                .as_ref()
+                .unwrap()
+                .usage
+                .input_tokens,
+            40
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn continuation_finishing_first_is_assembled_after_its_head() {
+        let first_poll = Rc::new(Cell::new(false));
+        let previews = Rc::new(RefCell::new(Vec::new()));
+        let preview_sink = Rc::clone(&previews);
+        let head = chunk("a.xhtml", "Cake\nflour");
+        let mut tail = chunk("b.xhtml", "Bake until done");
+        tail.title_hint = Some("Cake".to_string());
+        let report = extract_chunks_with(
+            vec![head, tail],
+            "book.epub",
+            &OrchestrationOptions {
+                concurrency: 2,
+                previews: true,
+                ..Default::default()
+            },
+            move |index, _, _| {
+                let first_poll = Rc::clone(&first_poll);
+                async move {
+                    if index == 0 {
+                        poll_fn(move |cx| {
+                            if first_poll.replace(true) {
+                                Poll::Ready(())
+                            } else {
+                                cx.waker().wake_by_ref();
+                                Poll::Pending
+                            }
+                        })
+                        .await;
+                    }
+                    Ok(outcome(
+                        vec![recipe("Cake", (index == 0).then_some("flour"))],
+                        0,
+                    ))
+                }
+            },
+            move |snapshot| preview_sink.borrow_mut().push(snapshot),
+        )
+        .await;
+
+        assert!(previews.borrow()[1].preview.as_ref().unwrap().is_empty());
+        assert_eq!(report.recipes.len(), 1);
+        assert_eq!(report.recipes[0].sections.len(), 2);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn complete_chunks_preserve_text_links_and_image_positions() {
+        let mut recipes = chunk(
+            "recipes.xhtml",
+            "Sauce\n1 item\nDish\n1 recipe Sauce (this page)",
+        );
+        recipes.images.extend([
+            (
+                0,
+                ImageRef {
+                    path: "sauce.jpg".to_string(),
+                    mime: "image/jpeg".to_string(),
+                    alt: None,
+                },
+            ),
+            (
+                2,
+                ImageRef {
+                    path: "dish.jpg".to_string(),
+                    mime: "image/jpeg".to_string(),
+                    alt: None,
+                },
+            ),
+        ]);
+        let mut links = chunk("links.xhtml", "Index");
+        links.links.push(crate::Link {
+            text: "Sauce".to_string(),
+            href: "recipes.xhtml#sauce".to_string(),
+        });
+        let report = extract_chunks_with(
+            vec![recipes, links],
+            "book.epub",
+            &OrchestrationOptions::default(),
+            |index, chunk, _| async move {
+                let extracted = if index == 0 {
+                    assert_eq!(
+                        chunk.text,
+                        "Sauce\n1 item\nDish\n1 recipe Sauce (this page)"
+                    );
+                    assert_eq!(chunk.images[0].0, 0);
+                    assert_eq!(chunk.images[1].0, 2);
+                    vec![
+                        recipe("Sauce", Some("1 item")),
+                        recipe("Dish", Some("1 recipe Sauce (this page)")),
+                    ]
+                } else {
+                    assert_eq!(chunk.text, "Index");
+                    assert_eq!(chunk.links.len(), 1);
+                    Vec::new()
+                };
+                Ok(outcome(extracted, 0))
+            },
+            |_| {},
+        )
+        .await;
+        assert_eq!(report.recipes[0].image.as_ref().unwrap().path, "sauce.jpg");
+        assert_eq!(report.recipes[1].image.as_ref().unwrap().path, "dish.jpg");
+        assert_eq!(report.recipes[1].references.len(), 1);
+        assert_eq!(
+            report.recipes[1].references[0].confidence,
+            crate::RefConfidence::Linked
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn concurrency_is_bounded_and_cached_progress_is_monotonic() {
+        let active = Rc::new(Cell::new(0usize));
+        let max_active = Rc::new(Cell::new(0usize));
+        let observed_max = Rc::clone(&max_active);
+        let progress = Rc::new(RefCell::new(Vec::new()));
+        let progress_sink = Rc::clone(&progress);
+        let chunks = (0..5)
+            .map(|index| chunk(&format!("{index}.xhtml"), &format!("Recipe {index}")))
+            .collect();
+        let report = extract_chunks_with(
+            chunks,
+            "book.epub",
+            &OrchestrationOptions {
+                concurrency: 2,
+                ..Default::default()
+            },
+            move |index, _, _| {
+                let active = Rc::clone(&active);
+                let max_active = Rc::clone(&max_active);
+                async move {
+                    let mut entered = false;
+                    poll_fn(move |cx| {
+                        if entered {
+                            active.set(active.get() - 1);
+                            Poll::Ready(())
+                        } else {
+                            entered = true;
+                            active.set(active.get() + 1);
+                            max_active.set(max_active.get().max(active.get()));
+                            cx.waker().wake_by_ref();
+                            Poll::Pending
+                        }
+                    })
+                    .await;
+                    Ok(ChunkOutcome {
+                        recipes: vec![recipe(&format!("Recipe {index}"), Some("item"))],
+                        usage: Usage::default(),
+                        cached: index % 2 == 0,
+                        truncated: false,
+                    })
+                }
+            },
+            move |snapshot| progress_sink.borrow_mut().push(snapshot),
+        )
+        .await;
+
+        assert_eq!(report.chunks.len(), 5);
+        assert_eq!(report.chunks_cached, 3);
+        assert_eq!(observed_max.get(), 2);
+        let snapshots = progress.borrow();
+        assert_eq!(snapshots.len(), 6);
+        assert!(
+            snapshots
+                .windows(2)
+                .all(|pair| pair[0].cached <= pair[1].cached)
+        );
+        assert_eq!(snapshots.last().unwrap().cached, 3);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn empty_and_zero_concurrency_are_valid() {
+        let calls = Cell::new(0);
+        let progress = RefCell::new(Vec::new());
+        let report = extract_chunks_with(
+            Vec::new(),
+            "book.epub",
+            &OrchestrationOptions {
+                concurrency: 0,
+                ..Default::default()
+            },
+            |_, _, _| {
+                calls.set(calls.get() + 1);
+                async { Ok(outcome(Vec::new(), 0)) }
+            },
+            |snapshot| progress.borrow_mut().push(snapshot),
+        )
+        .await;
+        assert!(report.recipes.is_empty());
+        assert_eq!(calls.get(), 0);
+        assert_eq!(progress.borrow().len(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn successful_truncation_is_reported_without_escalation() {
+        let calls = RefCell::new(Vec::new());
+        let report = extract_chunks_with(
+            vec![chunk("a.xhtml", "A")],
+            "book.epub",
+            &OrchestrationOptions {
+                concurrency: 0,
+                fallback: true,
+                ..Default::default()
+            },
+            |_, _, tier| {
+                calls.borrow_mut().push(tier);
+                async move {
+                    Ok(ChunkOutcome {
+                        recipes: vec![recipe("A", Some("a"))],
+                        usage: Usage::default(),
+                        cached: false,
+                        truncated: true,
+                    })
+                }
+            },
+            |_| {},
+        )
+        .await;
+        assert_eq!(&*calls.borrow(), &[ModelTier::Primary]);
+        assert_eq!(report.truncations.len(), 1);
+        assert_eq!(report.truncations[0].tier, ModelTier::Primary);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn disabled_fallback_reports_an_all_failed_book() {
+        let calls = Cell::new(0);
+        let report = extract_chunks_with(
+            vec![chunk("a.xhtml", "A")],
+            "book.epub",
+            &OrchestrationOptions::default(),
+            |_, _, tier| {
+                calls.set(calls.get() + 1);
+                async move {
+                    assert_eq!(tier, ModelTier::Primary);
+                    Err(failure("no recipe", 5, false))
+                }
+            },
+            |_| {},
+        )
+        .await;
+        assert!(report.recipes.is_empty());
+        assert!(report.chunks.is_empty());
+        assert_eq!(report.failures.len(), 1);
+        assert!(report.failures[0].fallback.is_none());
+        assert_eq!(calls.get(), 1);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detailed_retry_keeps_usage_from_retryable_call_failures() {
+        let calls = Cell::new(0);
+        let result = try_extract_chunk_detailed("doc", || {
+            let attempt = calls.get();
+            calls.set(attempt + 1);
+            async move {
+                if attempt == 0 {
+                    Err(CallFailure::retryable_payload(
+                        EpubError::Deserialize(
+                            serde_json::from_str::<serde_json::Value>("{").unwrap_err(),
+                        ),
+                        Usage {
+                            input_tokens: 7,
+                            ..Default::default()
+                        },
+                        false,
+                    ))
+                } else {
+                    Ok(CallResult {
+                        input: Some(serde_json::json!({
+                            "recipes": [{
+                                "title": "Recovered",
+                                "sections": [{ "ingredients": ["one"] }]
+                            }]
+                        })),
+                        usage: Usage {
+                            input_tokens: 11,
+                            ..Default::default()
+                        },
+                        truncated: false,
+                    })
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(calls.get(), 2);
+        assert_eq!(result.usage.input_tokens, 18);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn detailed_retry_failure_keeps_all_attempt_usage() {
+        let calls = Cell::new(0);
+        let failure = try_extract_chunk_detailed("doc", || {
+            let attempt = calls.get();
+            calls.set(attempt + 1);
+            async move {
+                if attempt == 0 {
+                    Ok(CallResult {
+                        input: Some(serde_json::json!({ "recipes": "[bad" })),
+                        usage: Usage {
+                            input_tokens: 7,
+                            ..Default::default()
+                        },
+                        truncated: false,
+                    })
+                } else {
+                    Err(CallFailure::transport_with_metadata(
+                        EpubError::Proxy("connection reset".to_string()),
+                        Usage {
+                            input_tokens: 11,
+                            ..Default::default()
+                        },
+                        false,
+                    ))
+                }
+            }
+        })
+        .await
+        .unwrap_err();
+        assert_eq!(calls.get(), 2);
+        assert_eq!(failure.usage.input_tokens, 18);
+        assert_eq!(failure.attempts.len(), 2);
+    }
+}

--- a/recipe-scraper/src/lib.rs
+++ b/recipe-scraper/src/lib.rs
@@ -7,10 +7,8 @@
 //! recipe markup) when a page has no usable LD+JSON. [`parse_sections`] runs
 //! each scraped ingredient line through `ingredient`'s parser.
 //!
-//! Several items are `pub` beyond what this workspace itself needs because
-//! cubby's `recipebridge` crate (a separate, external repo) depends on this
-//! crate directly and calls them — see the `parse_yield_string` re-export
-//! below for the canonical example; don't narrow visibility without checking.
+//! Public re-exports such as `parse_yield_string` are used by external callers;
+//! preserve their visibility even when no workspace caller needs them.
 
 use chefsteps::parse_chefsteps;
 use html::scrape_from_html;
@@ -21,8 +19,7 @@ use ingredient::{
     rich_text::{Rich, RichParser},
 };
 use ld_json::extract_ld;
-// Re-exported on purpose: cubby's recipebridge wasm crate (separate repo)
-// calls `recipe_scraper::parse_yield_string` — pub(crate) breaks its build.
+// Public entrypoint for callers parsing yields without scraping a page.
 pub use ld_json::parse_yield_string;
 use scraper::Html;
 


### PR DESCRIPTION
Share EPUB scheduling, escalation, failure salvage and ordered assembly through `extract_chunks_with`. Callers supply extraction transport; HTTP, filesystem caching and browser bindings remain outside the driver.

Preserve complete chunks for image association and continuation merging. Support incremental previews and report detailed failures, per-tier usage and truncation. Native entrypoints retain their configuration, caching and public interfaces.

Tested with workspace build/nextest, doctests, strict Clippy and hooks. CI tests the non-native library and compiles a non-Send callback example for WASM. Cases cover completion order, concurrency, fallback, truncation, failed-attempt usage and image/link association.

A separate lockfile commit replaces yanked `chacha20 0.10.0` with compatible `0.10.2` to clear cargo-deny. Independent of #371.
