### PR TITLE
Preserve rich-text prose and model-attributed EPUB accounting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -90,3 +90,13 @@ _Avoid_: section, segment, page
 The section title carried forward onto a continuation chunk, so a recipe split across a
 chunk seam is re-emitted under the same title and can be merged back together.
 _Avoid_: continuation marker, carryover
+
+**Extraction accounting**:
+The usage attributable to each model that processed a cookbook, together with evidence
+of failed or truncated Chunks. Recovered recipes remain usable even when extraction is incomplete.
+_Avoid_: billing record, invoice
+
+**Known cost subtotal**:
+The estimated cost of extraction usage for which the model's rate is known. It is a
+complete estimate only when every model with reported usage has a known rate.
+_Avoid_: total cost (when rates are missing)

--- a/food-app/src/tabs/cookbook.rs
+++ b/food-app/src/tabs/cookbook.rs
@@ -14,8 +14,8 @@ use petgraph::Directed;
 use petgraph::stable_graph::{DefaultIx, NodeIndex, StableGraph};
 use poll_promise::Promise;
 use recipe_epub::{
-    BookMeta, CookbookGuess, CookbookRecipe, CookbookRecipeExt, ExtractionStats, ImageRef, Options,
-    ParsedCookbookRecipe,
+    BookMeta, CookbookGuess, CookbookRecipe, CookbookRecipeExt, ExtractionAccounting, ImageRef,
+    Options, ParsedCookbookRecipe,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 /// the first frame they're observed, then referenced by `Image::from_uri`.
 struct LoadedBook {
     recipes: Vec<CookbookRecipe>,
-    stats: ExtractionStats,
+    stats: ExtractionAccounting,
     /// The book's cover reference (URI key), if any.
     cover: Option<ImageRef>,
     /// De-duplicated `(archive_path, bytes)` for the cover + all heroes.
@@ -376,25 +376,8 @@ impl CookbookTab {
                     }
                     ui.label(RichText::new(format!("{} recipes", recipes.len())).weak());
                     ui.separator();
-                    let cost = stats
-                        .cost_usd()
-                        .map_or_else(|| "cost n/a".to_string(), |c| format!("~${c:.4}"));
-                    ui.label(
-                        RichText::new(format!(
-                            "{cost} · {}/{} chunks cached",
-                            stats.chunks_cached, stats.chunks_total
-                        ))
-                        .weak()
-                        .small(),
-                    )
-                    .on_hover_text(format!(
-                        "model: {}\n{} input tok\n{} output tok\n{} cache-read tok\n{} cache-write tok",
-                        stats.model,
-                        stats.usage.input_tokens,
-                        stats.usage.output_tokens,
-                        stats.usage.cache_read_input_tokens,
-                        stats.usage.cache_creation_input_tokens,
-                    ));
+                    ui.label(RichText::new(stats.status_summary()).weak().small())
+                        .on_hover_text(stats.summary());
                     ui.separator();
                     // Browse | Graph toggle. The graph is only useful when there
                     // are references to draw.
@@ -562,7 +545,7 @@ impl CookbookTab {
                     ..Default::default()
                 };
                 let (recipes, stats) = rt
-                    .block_on(recipe_epub::extract_cookbook_with_progress(
+                    .block_on(recipe_epub::extract_cookbook_detailed_with_progress(
                         &bytes,
                         &path,
                         &opts,

--- a/food-cli/src/main.rs
+++ b/food-cli/src/main.rs
@@ -356,10 +356,10 @@ async fn main() {
                 use_cache: !no_cache,
                 ..Default::default()
             };
-            match recipe_epub::extract_cookbook(&bytes, path, &opts).await {
+            match recipe_epub::extract_cookbook_detailed(&bytes, path, &opts).await {
                 Ok((recipes, stats)) => {
                     // Cost/cache summary goes to stderr so --json stdout stays clean.
-                    eprintln!("[{}] {}", stats.model, stats.summary());
+                    eprintln!("{}", stats.summary());
                     // A valid EPUB that yields nothing is almost always an
                     // extraction bug (e.g. a content-decode failure), not an empty
                     // book — make it loud instead of exiting 0 with no output.
@@ -520,7 +520,7 @@ async fn main() {
                             Ok(b) => b,
                             Err(e) => return (p, Err(format!("read error: {e}"))),
                         };
-                        let result = recipe_epub::extract_cookbook(&bytes, &p, opts)
+                        let result = recipe_epub::extract_cookbook_detailed(&bytes, &p, opts)
                             .await
                             .map_err(|e| e.to_string());
                         (p, result)
@@ -542,10 +542,9 @@ async fn main() {
                         total_recipes += recipes.len();
                         total_chunks += stats.chunks_total;
                         total_chunks_cached += stats.chunks_cached;
-                        match stats.cost_usd() {
-                            Some(c) => total_cost += c,
-                            None => cost_known = false,
-                        }
+                        let estimate = stats.cost_estimate();
+                        total_cost += estimate.known_usd;
+                        cost_known &= estimate.complete;
                         for r in &recipes {
                             total_lines += r
                                 .sections
@@ -567,7 +566,7 @@ async fn main() {
             let cost_str = if cost_known {
                 format!("~${total_cost:.4}")
             } else {
-                "n/a".to_string()
+                format!("~${total_cost:.4} known subtotal (pricing incomplete)")
             };
             println!(
                 "scanned {} book(s): {total_recipes} recipes, {total_lines} ingredient lines, \

--- a/ingredient-parser/src/parser/measurement/mod.rs
+++ b/ingredient-parser/src/parser/measurement/mod.rs
@@ -8,13 +8,15 @@
 //! The same parsers serve two modes, selected by the [`MeasurementMode`] on
 //! [`MeasurementParser`]: **ingredient-list** mode (the default — "2 cups flour")
 //! and **rich-text/prose** mode (measurements embedded in instructions — "cook for
-//! 30 minutes"). The modes share ~90% of the logic; prose mode only adds a few
-//! *rejections* so noise isn't mistaken for a quantity. Every fork point:
+//! 30 minutes"). Both share number and unit recognition. Prose leaves surrounding
+//! text unconsumed instead of using ingredient-list assembly shortcuts:
 //!
 //! - `number::parse_number` — prose mode excludes spelled-out text numbers
 //!   ("one", "a") so words like "a pinch" or "one more" aren't read as counts.
 //! - `single::rejected_in_rich_text` — prose mode rejects step numbers
-//!   ("1. Bring…") and dimension suffixes ("1-inch piece"). See that method.
+//!   ("1. Bring…"); dimensions such as "1-inch piece" remain Measures.
+//! - `parse_prose_measurement` — leaves list separators and parentheses as prose.
+//! - `single::leading_qualifier` / `trailing_prose` — retain surrounding text.
 //! - `single::parse_unit_only` — disabled entirely in prose (a bare unit like
 //!   "cup" in prose is a noun, not "1 cup"); only fires in ingredient-list mode.
 //!
@@ -34,8 +36,6 @@ use nom::{Parser, branch::alt, bytes::complete::tag, error::context, multi::sepa
 use crate::parser::Res;
 use crate::traced_parser;
 use crate::unit::Measure;
-
-use self::guards::optional_period_or_of;
 
 /// Shared test fixture data for the measurement submodules' co-located tests.
 #[cfg(test)]
@@ -102,6 +102,21 @@ impl<'a> MeasurementParser<'a> {
     /// Create a new measurement parser with the given configuration
     pub fn new(units: &'a HashSet<String>, mode: MeasurementMode) -> Self {
         Self { units, mode }
+    }
+
+    /// Recognize one Measure expression in prose. Ingredient-list separators,
+    /// parentheses and assembly shortcuts are prose here, so they stay with the
+    /// caller. Cross-unit ranges still belong to a single Measure expression.
+    pub(crate) fn parse_prose_measurement<'b>(&self, input: &'b str) -> Res<&'b str, Vec<Measure>> {
+        alt((
+            |i| self.parse_cross_unit_range(i),
+            nom::combinator::map_opt(|i| self.parse_range_with_units(i), |m| m.map(|m| vec![m])),
+            |i| {
+                self.parse_single_measurement(i)
+                    .map(|(rest, m)| (rest, vec![m]))
+            },
+        ))
+        .parse(input)
     }
 
     /// Parse a list of measurements with different separators

--- a/ingredient-parser/src/parser/measurement/range.rs
+++ b/ingredient-parser/src/parser/measurement/range.rs
@@ -13,7 +13,7 @@ use crate::parser::Res;
 use crate::traced_parser;
 use crate::unit::{Measure, Unit};
 
-use super::{DEFAULT_UNIT, MeasurementParser, optional_period_or_of};
+use super::{DEFAULT_UNIT, MeasurementParser};
 
 /// Canonical [`Unit`] for a raw unit spelling, so range endpoints compare by
 /// unit identity rather than spelling ("tsp" == "teaspoons", "g" == "G").
@@ -46,7 +46,7 @@ impl<'a> MeasurementParser<'a> {
             |a| self.parse_number(a), // upper value
             space1,
             |a| self.unit(a), // upper unit (required)
-            optional_period_or_of,
+            |i| self.trailing_prose(i),
         );
 
         traced_parser!(
@@ -140,13 +140,13 @@ impl<'a> MeasurementParser<'a> {
         // Format for a measurement with a range
         let range_format = (
             // Optional approximation qualifier ("about", "roughly", …, any case)
-            nom::combinator::opt(super::single::leading_qualifier),
+            |i| self.leading_qualifier(i),
             |a| self.parse_value(a),                // The lower value
             space0,                                 // Optional whitespace
             nom::combinator::opt(|a| self.unit(a)), // Optional unit for lower value
             |a| self.parse_range_end(a),            // The upper range value
             nom::combinator::opt(|a| self.unit(a)), // Optional unit for upper value
-            optional_period_or_of,                  // Optional period or "of"
+            |i| self.trailing_prose(i),             // Optional period or "of"
         );
 
         traced_parser!(

--- a/ingredient-parser/src/parser/measurement/single.rs
+++ b/ingredient-parser/src/parser/measurement/single.rs
@@ -26,15 +26,16 @@ impl<'a> MeasurementParser<'a> {
     /// description appears between the number and unit.
     pub(super) fn parse_single_measurement<'b>(&self, input: &'b str) -> Res<&'b str, Measure> {
         let measurement_parser = (
-            opt(leading_qualifier),
+            |i| self.leading_qualifier(i),
             opt(|a| self.parse_multiplier(a)),
             |a| self.parse_value(a),
+            peek(nom::combinator::rest),
             space0,
             optional_dash_separator,
             optional_article,
             opt(amount_qualifier_between),
             opt(|a| self.unit(a)),
-            optional_period_or_of,
+            |i| self.trailing_prose(i),
         );
 
         traced_parser!(
@@ -47,6 +48,7 @@ impl<'a> MeasurementParser<'a> {
                         _estimate_prefix,
                         multiplier,
                         value,
+                        after_value,
                         _,
                         _dash,
                         _article,
@@ -63,6 +65,7 @@ impl<'a> MeasurementParser<'a> {
                         Some(m) => (value.0 * m, value.1.map(|upper| upper * m)),
                         None => (value.0, value.1),
                     };
+                    let explicit_unit = unit.is_some();
                     let (final_next_input, final_unit) = self.resolve_single_measurement_unit(
                         input,
                         next_input,
@@ -70,14 +73,45 @@ impl<'a> MeasurementParser<'a> {
                         period_consumed,
                     )?;
 
+                    // A bare count has no unit to justify consuming the space,
+                    // article or qualifier following its value. Leave that prose
+                    // untouched instead of asking callers to reconstruct it.
+                    let rest = if self.mode == MeasurementMode::RichText
+                        && !explicit_unit
+                        && final_unit == DEFAULT_UNIT
+                        && final_next_input.len() == next_input.len()
+                    {
+                        after_value
+                    } else {
+                        final_next_input
+                    };
                     Ok((
-                        final_next_input,
+                        rest,
                         Measure::from_parts(final_unit.as_ref(), final_value, final_upper),
                     ))
                 }),
             |m: &Measure| m.to_string(),
             "no measurement"
         )
+    }
+
+    /// Prose keeps leading qualifiers as text; ingredient lines discard them.
+    pub(super) fn leading_qualifier<'b>(&self, input: &'b str) -> Res<&'b str, Option<()>> {
+        if self.mode == MeasurementMode::RichText {
+            Ok((input, None))
+        } else {
+            opt(leading_qualifier).parse(input)
+        }
+    }
+
+    /// Inspect a terminator for number disambiguation, but only consume it in
+    /// ingredient-list mode. The grammar owns this choice for all callers.
+    pub(super) fn trailing_prose<'b>(&self, input: &'b str) -> Res<&'b str, Option<&'b str>> {
+        if self.mode == MeasurementMode::RichText {
+            peek(optional_period_or_of).parse(input)
+        } else {
+            optional_period_or_of(input)
+        }
     }
 
     /// In rich-text (prose) mode, reject a bare number whose continuation is not
@@ -108,7 +142,9 @@ impl<'a> MeasurementParser<'a> {
             return Ok((next_input, unit.to_lowercase()));
         }
 
-        if let Some((after_paren, unit)) = self.parse_unit_after_parens(next_input) {
+        if self.mode == MeasurementMode::IngredientList
+            && let Some((after_paren, unit)) = self.parse_unit_after_parens(next_input)
+        {
             return Ok((after_paren, unit));
         }
 
@@ -409,8 +445,7 @@ fn size_word_before_discardable_unit(input: &str) -> Res<&str, &str> {
 /// Consume a leading approximation/size qualifier ("about", "roughly",
 /// "generous", "scant", …), optionally preceded by an article ("a"/"an"), so
 /// the amount after it still parses. Case-insensitive; the qualifier text is
-/// discarded — except by `rich_text`, which re-emits the consumed span as
-/// prose (the reason this is pub(crate)).
+/// discarded in ingredient-list mode. Rich-text mode leaves it unconsumed.
 ///
 /// Wrapped in `opt(...)` by the caller, so a partial match (e.g. consuming "a "
 /// then failing) backtracks and consumes nothing.

--- a/ingredient-parser/src/rich_text.rs
+++ b/ingredient-parser/src/rich_text.rs
@@ -2,11 +2,13 @@ use std::collections::HashSet;
 
 use crate::{
     IngredientParser, Res,
-    parser::measurement::single::leading_qualifier,
     parser::{MeasurementMode, MeasurementParser},
     unit::Measure,
 };
-use nom::{Parser, branch::alt, character::complete::satisfy, error::context, multi::many0};
+use nom::{
+    Parser, branch::alt, character::complete::anychar, combinator::all_consuming, error::context,
+    multi::many0,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -234,75 +236,13 @@ fn extract_ingredients(r: Rich, ingredient_names: &[String]) -> Rich {
 }
 
 fn amounts_chunk<'a>(units: &HashSet<String>, input: &'a str) -> Res<&'a str, Vec<Chunk>> {
-    // Always use rich text mode (true) for instruction parsing
     let mp = MeasurementParser::new(units, MeasurementMode::RichText);
-    let (next_input, measures) =
-        context("amounts_chunk", |a| mp.parse_measurement_list(a)).parse(input)?;
-
-    // The measurement parser swallows a leading approximation qualifier
-    // ("about ", "roughly ", …) and a trailing sentence boundary (". " / "." /
-    // " of") around the measure. Those are noise for ingredient amounts but
-    // real prose in instructions, so re-emit them as Text instead of deleting
-    // them — otherwise the measure glues onto the next sentence (e.g.
-    // "...foamy, about 3 minutes. Continue" → "...foamy, 3 minutesContinue").
-    let consumed = &input[..input.len() - next_input.len()];
-    let leading_len = match leading_qualifier(input) {
-        Ok((rest, ())) => input.len() - rest.len(),
-        Err(_) => 0,
-    };
-
-    let mut chunks = Vec::with_capacity(3);
-    if leading_len > 0 {
-        chunks.push(Chunk::Text(input[..leading_len].to_string()));
-    }
-    chunks.push(Chunk::Measure(measures));
-    let trailing = trailing_boundary(consumed);
-    if !trailing.is_empty() {
-        chunks.push(Chunk::Text(trailing.to_string()));
-    } else {
-        // A unitless bare count ("12 cookies") consumes the trailing space via
-        // `space0` but never uses it; re-emit it so the next word keeps its
-        // leading space (otherwise "12 cookies" → measure + "cookies").
-        let stripped = consumed.trim_end_matches(char::is_whitespace);
-        if stripped.len() < consumed.len() {
-            chunks.push(Chunk::Text(consumed[stripped.len()..].to_string()));
-        }
-    }
-    Ok((next_input, chunks))
-}
-
-/// The sentence boundary the measure parser's `optional_period_or_of` swallows
-/// after a measure, so rich text can re-emit it as prose.
-fn trailing_boundary(consumed: &str) -> &'static str {
-    if consumed.ends_with(". ") {
-        ". "
-    } else if consumed.ends_with(" of") {
-        " of"
-    } else if consumed.ends_with('.') {
-        "."
-    } else {
-        ""
-    }
+    mp.parse_prose_measurement(input)
+        .map(|(rest, measures)| (rest, vec![Chunk::Measure(measures)]))
 }
 
 fn text_chunk(input: &str) -> Res<&str, Vec<Chunk>> {
-    parse_rich_char(input).map(|(next_input, res)| (next_input, vec![Chunk::Text(res)]))
-}
-/// Parse a single text character for rich text (recipe instructions).
-///
-/// Allows: alphanumeric, whitespace, plus additional punctuation
-/// (commas, parentheses, semicolons, colons, slashes, etc.)
-///
-/// Note: This is more permissive than `parser::helpers::parse_ingredient_text()` which is
-/// designed for ingredient names only.
-fn parse_rich_char(input: &str) -> Res<&str, String> {
-    satisfy(|c| match c {
-        '-' | '\u{2014}' | '\'' | '\u{2019}' | '.' | '\\' => true,
-        ',' | '(' | ')' | ';' | '#' | '/' | ':' | '!' => true,
-        c => c.is_alphanumeric() || c.is_whitespace(),
-    })
-    .parse(input)
-    .map(|(next_input, res)| (next_input, res.to_string()))
+    anychar(input).map(|(rest, c)| (rest, vec![Chunk::Text(c.to_string())]))
 }
 /// Parse some rich text that has some parsable [Measure] scattered around in it. Useful for displaying text with fancy formatting.
 /// returns [Rich]
@@ -353,7 +293,7 @@ impl RichParser {
         let units = self.ip.units();
         match context(
             "amts",
-            many0(alt((|a| amounts_chunk(units, a), text_chunk))),
+            all_consuming(many0(alt((|a| amounts_chunk(units, a), text_chunk)))),
         )
         .parse(input)
         {
@@ -403,6 +343,38 @@ mod tests {
             reason: "boom".into(),
         };
         assert_eq!(err.to_string(), "unable to parse '2 cups flour': boom");
+    }
+
+    #[rstest]
+    #[case("Mix? Add 2 cups flour 😀", "Mix? Add <2 cups> flour 😀")]
+    #[case(
+        "Salt & pepper\nthen 2 cups flour",
+        "Salt & pepper\nthen <2 cups> flour"
+    )]
+    #[case("About 3 minutes. Continue", "About <3 minutes>. Continue")]
+    #[case("Add (2 cups) of flour", "Add (<2 cups>) of flour")]
+    #[case("Use 12\t cookies", "Use <12>\t cookies")]
+    #[case("Use 2 cups, 3 tbsp; then stir", "Use <2 cups>, <3 tbsp>; then stir")]
+    #[case("Add 2 cups of flour", "Add <2 cups> of flour")]
+    #[case("Use 2 tsp to 3 tbsp. Stir", "Use <2 tsp|3 tbsp>. Stir")]
+    #[case("Use 1 (well beaten) egg", "Use <1> (well beaten) egg")]
+    #[case("Use ½ cup flour", "Use <½ cup> flour")]
+    fn test_prose_survives_measure_recognition(#[case] input: &str, #[case] expected: &str) {
+        let parsed = RichParser::default().parse(input).unwrap();
+        let rendered: String = parsed
+            .into_iter()
+            .map(|chunk| match chunk {
+                Chunk::Text(s) | Chunk::Ing(s) => s,
+                Chunk::Measure(ms) => format!(
+                    "<{}>",
+                    ms.iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join("|")
+                ),
+            })
+            .collect();
+        assert_eq!(rendered, expected);
     }
 
     #[rstest]
@@ -708,7 +680,7 @@ mod tests {
     }
 
     // ============================================================================
-    // parse_rich_char() Parser Tests
+    // Complete prose through the public parser
     // ============================================================================
 
     #[rstest]
@@ -719,8 +691,11 @@ mod tests {
     #[case::comma(",")]
     #[case::slash("/")]
     #[case::hash("#")]
-    fn test_parse_rich_char_special_chars(#[case] input: &str) {
-        assert!(parse_rich_char(input).is_ok());
+    fn test_prose_special_chars(#[case] input: &str) {
+        assert_eq!(
+            RichParser::default().parse(input).unwrap(),
+            vec![Chunk::Text(input.to_string())]
+        );
     }
 
     // ============================================================================

--- a/ingredient-parser/tests/corpus/rich_text.jsonl
+++ b/ingredient-parser/tests/corpus/rich_text.jsonl
@@ -83,3 +83,6 @@
 {"input": "Roll into 1-inch balls", "chunks": [{"text": "Roll into "}, {"measure": [{"unit": "inch", "value": 1.0}]}, {"text": " balls"}]}
 // Garnish callout with ingredient mid-sentence.
 {"input": "Serve hot, sprinkled with parsley", "ingredients": ["flat-leaf parsley"], "chunks": [{"text": "Serve hot, sprinkled with "}, {"ing": "parsley"}]}
+
+// Prose survives Measure recognition, including a range with attached units.
+{"input":"Use 78g to 104g. Stir? Then serve 😀","chunks":[{"text":"Use "},{"measure":[{"unit":"g","value":78.0,"upper_value":104.0}]},{"text":". Stir? Then serve 😀"}]}

--- a/ingredient-parser/tests/property.rs
+++ b/ingredient-parser/tests/property.rs
@@ -31,6 +31,25 @@ prop_compose! {
 }
 
 proptest! {
+    /// With no numeric expressions to normalize, every authored character must
+    /// survive the same rich-text interface used by recipe readers.
+    #[test]
+    fn rich_prose_preserves_nonnumeric_unicode(
+        chars in prop::collection::vec(any::<char>().prop_filter("prose", |c| !c.is_numeric()), 0..100)
+    ) {
+        use ingredient::rich_text::{Chunk, RichParser};
+        let input: String = chars.into_iter().collect();
+        let rich = RichParser::new(["flour", "salt"]).parse(&input).unwrap();
+        let mut text = String::new();
+        for chunk in rich {
+            match chunk {
+                Chunk::Text(s) | Chunk::Ing(s) => text.push_str(&s),
+                Chunk::Measure(_) => prop_assert!(false, "unexpected Measure in {input:?}"),
+            }
+        }
+        prop_assert_eq!(text, input);
+    }
+
     /// Test that parser never panics on arbitrary input
     #[test]
     fn parser_never_panics(input in arb_text_input()) {

--- a/recipe-epub/src/accounting.rs
+++ b/recipe-epub/src/accounting.rs
@@ -1,0 +1,356 @@
+//! Extraction accounting shared by native and browser readers. Transport adapters
+//! supply model identity; this module retains tier attribution and incompleteness
+//! through cost estimation and human summaries.
+
+#[cfg(any(feature = "native", test))]
+use crate::ExtractionStats;
+use crate::{ChunkTruncation, ExtractionReport, ModelTier, Usage};
+use serde::Serialize;
+
+/// Usage attributable to one extraction tier. An absent model is unpriced.
+#[derive(Debug, Clone, Serialize)]
+pub struct ModelUsage {
+    pub tier: ModelTier,
+    pub model: Option<String>,
+    pub usage: Usage,
+}
+
+/// A subtotal of known rates, explicitly distinguished from a complete estimate.
+#[derive(Debug, Clone, Copy, Default, Serialize)]
+pub struct CostEstimate {
+    pub known_usd: f64,
+    pub complete: bool,
+}
+
+impl std::fmt::Display for CostEstimate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.complete {
+            write!(f, "~${:.4}", self.known_usd)
+        } else {
+            write!(
+                f,
+                "~${:.4} known subtotal (pricing incomplete)",
+                self.known_usd
+            )
+        }
+    }
+}
+
+/// Accounting for a book, retaining usage by model and incomplete extraction.
+/// Created from the shared report so every reader uses the same attribution.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractionAccounting {
+    pub models: Vec<ModelUsage>,
+    pub usage: Usage,
+    pub chunks_total: usize,
+    pub chunks_cached: usize,
+    pub chunks_failed: usize,
+    /// Successful chunks whose final result was truncated (recovered attempts excluded).
+    pub chunks_truncated: usize,
+    pub truncations: Vec<ChunkTruncation>,
+}
+
+impl ExtractionReport {
+    /// Attribute the report to the models selected by the transport adapter.
+    /// Missing identities remain unpriced; a fallback is never priced as primary.
+    /// This is additive: existing browser report construction remains unchanged.
+    pub fn accounting(
+        &self,
+        primary_model: &str,
+        fallback_model: Option<&str>,
+    ) -> ExtractionAccounting {
+        let model = |s: &str| (!s.is_empty()).then(|| s.to_owned());
+        let mut models = vec![ModelUsage {
+            tier: ModelTier::Primary,
+            model: model(primary_model),
+            usage: self.primary_usage.clone(),
+        }];
+        if self.chunks.iter().any(|c| c.tier == ModelTier::Fallback)
+            || self.failures.iter().any(|f| f.fallback.is_some())
+            || self.fallback_usage != Usage::default()
+        {
+            models.push(ModelUsage {
+                tier: ModelTier::Fallback,
+                model: fallback_model.and_then(model),
+                usage: self.fallback_usage.clone(),
+            });
+        }
+        ExtractionAccounting {
+            models,
+            usage: self.usage.clone(),
+            chunks_total: self.chunks.len() + self.failures.len(),
+            chunks_cached: self.chunks_cached,
+            chunks_failed: self.failures.len(),
+            chunks_truncated: self.chunks.iter().filter(|c| c.truncated).count(),
+            truncations: self.truncations.clone(),
+        }
+    }
+}
+
+impl ExtractionAccounting {
+    pub fn cost_estimate(&self) -> CostEstimate {
+        let mut estimate = CostEstimate {
+            known_usd: 0.0,
+            complete: true,
+        };
+        for model in &self.models {
+            // Cache hits make no billed calls, even with an unknown model.
+            if model.usage == Usage::default() {
+                continue;
+            }
+            match model
+                .model
+                .as_deref()
+                .and_then(|id| cost_for_usage(id, &model.usage))
+            {
+                Some(cost) => estimate.known_usd += cost,
+                None => estimate.complete = false,
+            }
+        }
+        estimate
+    }
+
+    /// Final chunk outcomes determine completeness. A truncated primary attempt
+    /// recovered by a complete fallback remains evidence, not a missing recipe.
+    pub fn is_incomplete(&self) -> bool {
+        self.chunks_failed > 0 || self.chunks_truncated > 0
+    }
+
+    /// One summary for CLI and desktop readers, including tier-specific usage.
+    pub fn summary(&self) -> String {
+        let models = self
+            .models
+            .iter()
+            .map(|m| {
+                format!(
+                    "{}: {} in / {} out / {} cache-read / {} cache-write tok",
+                    m.model.as_deref().unwrap_or("unknown model"),
+                    m.usage.input_tokens,
+                    m.usage.output_tokens,
+                    m.usage.cache_read_input_tokens,
+                    m.usage.cache_creation_input_tokens,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("; ");
+        format!("{} · {models}", self.status_summary())
+    }
+
+    /// Compact cost, cache and completeness summary for a visible recipe header.
+    pub fn status_summary(&self) -> String {
+        let status = if self.is_incomplete() {
+            format!(
+                " · INCOMPLETE: {} chunk(s) FAILED, {} chunk(s) truncated",
+                self.chunks_failed, self.chunks_truncated
+            )
+        } else if !self.truncations.is_empty() {
+            format!(
+                " · {} truncated attempt(s), recovered",
+                self.truncations.len()
+            )
+        } else {
+            String::new()
+        };
+        format!(
+            "{}/{} chunks cached · {}{status}",
+            self.chunks_cached,
+            self.chunks_total,
+            self.cost_estimate()
+        )
+    }
+
+    /// Compatibility projection. A single model can represent all billed usage
+    /// only when every billed tier has that identity; otherwise cost is unknown.
+    #[cfg(any(feature = "native", test))]
+    pub(crate) fn legacy_stats(&self) -> ExtractionStats {
+        let mut billed = self.models.iter().filter(|m| m.usage != Usage::default());
+        let first = billed.next().or_else(|| self.models.first());
+        let model = first.and_then(|m| m.model.as_deref());
+        let model = if billed.all(|m| m.model.as_deref() == model) {
+            model
+        } else {
+            None
+        };
+        ExtractionStats {
+            model: model.unwrap_or_default().to_owned(),
+            chunks_total: self.chunks_total,
+            chunks_cached: self.chunks_cached,
+            chunks_failed: self.chunks_failed,
+            usage: self.usage.clone(),
+        }
+    }
+}
+
+pub(crate) fn cost_for_usage(model: &str, u: &Usage) -> Option<f64> {
+    let (input, output) = price_per_mtok(model)?;
+    Some(
+        (u.input_tokens as f64 * input
+            + u.cache_creation_input_tokens as f64 * input * 1.25
+            + u.cache_read_input_tokens as f64 * input * 0.1
+            + u.output_tokens as f64 * output)
+            / 1_000_000.0,
+    )
+}
+
+/// Per-million-token (input, output) USD rates for known models. Matched by
+/// substring so dated ids (`claude-haiku-4-5-20251001`) resolve. `None` → the
+/// cost is reported as "n/a" rather than guessed.
+fn price_per_mtok(model: &str) -> Option<(f64, f64)> {
+    let m = model.to_lowercase();
+    let table = [
+        ("haiku", (1.0, 5.0)),
+        ("sonnet", (3.0, 15.0)),
+        // Pinned to opus-4-5: older Opus models have different (higher) rates,
+        // so they fall through to "n/a" rather than a wrong estimate.
+        ("opus-4-5", (5.0, 25.0)),
+        ("gemini-2.5-flash-lite", (0.10, 0.40)),
+        ("gemini-2.5-flash", (0.30, 2.50)),
+        ("gemini-2.0-flash-lite", (0.075, 0.30)),
+        ("gemini-2.0-flash", (0.10, 0.40)),
+    ];
+    // Longest matching key wins, so the most specific id resolves regardless of
+    // table order: "gemini-2.5-flash-lite" must not match the shorter
+    // "gemini-2.5-flash" prefix. This removes the order-dependence that a plain
+    // first-match `find` would silently rely on.
+    table
+        .iter()
+        .filter(|(key, _)| m.contains(key))
+        .max_by_key(|(key, _)| key.len())
+        .map(|(_, rate)| *rate)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+    use crate::{Chunk, ChunkOutcome, EpubError, OrchestrationOptions, extract_chunks_with};
+    use rstest::rstest;
+
+    #[test]
+    fn price_per_mtok_prefers_most_specific_key() {
+        // "...flash-lite" must resolve to the lite rate, not the shorter "flash"
+        // prefix it also contains — longest-match-wins, independent of table order.
+        assert_eq!(
+            price_per_mtok("gemini-2.5-flash-lite-preview"),
+            Some((0.10, 0.40))
+        );
+        assert_eq!(price_per_mtok("gemini-2.5-flash-002"), Some((0.30, 2.50)));
+        assert_eq!(price_per_mtok("gemini-2.0-flash-lite"), Some((0.075, 0.30)));
+        assert_eq!(price_per_mtok("gemini-2.0-flash"), Some((0.10, 0.40)));
+        // Dated Anthropic ids still resolve by substring.
+        assert_eq!(
+            price_per_mtok("claude-haiku-4-5-20251001"),
+            Some((1.0, 5.0))
+        );
+        // Unmapped → None.
+        assert_eq!(price_per_mtok("opus-4-1"), None);
+    }
+
+    #[rstest]
+    #[case(Some("claude-sonnet"), 7.0, true, true)]
+    #[case(Some("claude-sonnet"), 7.0, true, false)]
+    #[case(Some("unpriced"), 1.0, false, true)]
+    #[case(None, 1.0, false, true)]
+    #[tokio::test]
+    async fn report_prices_failed_primary_and_fallback_separately(
+        #[case] fallback: Option<&str>,
+        #[case] cost: f64,
+        #[case] complete: bool,
+        #[case] truncated: bool,
+    ) {
+        let report = extract_chunks_with(
+            vec![Chunk {
+                text: "recipe".into(),
+                doc_path: "one.xhtml".into(),
+                title_hint: None,
+                links: vec![],
+                images: vec![],
+            }],
+            "book",
+            &OrchestrationOptions {
+                fallback: true,
+                ..Default::default()
+            },
+            |_, _, tier| async move {
+                if tier == ModelTier::Primary {
+                    Err(crate::ChunkExtractionFailure {
+                        error: EpubError::Proxy("bad payload".into()),
+                        usage: Usage {
+                            input_tokens: 1_000_000,
+                            ..Default::default()
+                        },
+                        truncated: true,
+                        attempts: vec![],
+                    })
+                } else {
+                    Ok(ChunkOutcome {
+                        recipes: vec![crate::ExtractedRecipe {
+                            meta: crate::RecipeMeta {
+                                title: "Soup".into(),
+                                ..Default::default()
+                            },
+                            sections: vec![crate::RecipeSection::new(
+                                vec!["1 cup water".into()],
+                                vec![],
+                            )],
+                        }],
+                        usage: Usage {
+                            input_tokens: 2_000_000,
+                            ..Default::default()
+                        },
+                        cached: false,
+                        truncated,
+                    })
+                }
+            },
+            |_| {},
+        )
+        .await;
+        assert_eq!(report.recipes.len(), 1);
+        let accounting = report.accounting("claude-haiku", fallback);
+        assert_eq!(accounting.cost_estimate().known_usd, cost);
+        assert_eq!(accounting.cost_estimate().complete, complete);
+        assert_eq!(accounting.models.len(), 2);
+        assert_eq!(accounting.models[0].usage.input_tokens, 1_000_000);
+        assert_eq!(accounting.models[1].usage.input_tokens, 2_000_000);
+        assert_eq!(accounting.is_incomplete(), truncated);
+        assert_eq!(accounting.chunks_failed, 0);
+        assert_eq!(accounting.truncations.len(), if truncated { 2 } else { 1 });
+        assert_eq!(accounting.summary().contains("INCOMPLETE"), truncated);
+        assert_eq!(
+            accounting.summary().contains("pricing incomplete"),
+            !complete
+        );
+        assert!(accounting.legacy_stats().cost_usd().is_none());
+    }
+
+    #[tokio::test]
+    async fn cached_unknown_model_has_complete_zero_cost() {
+        let report = extract_chunks_with(
+            vec![Chunk {
+                text: "recipe".into(),
+                doc_path: "one.xhtml".into(),
+                title_hint: None,
+                links: vec![],
+                images: vec![],
+            }],
+            "book",
+            &OrchestrationOptions::default(),
+            |_, _, _| async {
+                Ok(ChunkOutcome {
+                    recipes: vec![],
+                    usage: Usage::default(),
+                    cached: true,
+                    truncated: false,
+                })
+            },
+            |_| {},
+        )
+        .await;
+        let accounting = report.accounting("unpriced", None);
+        assert_eq!(accounting.chunks_cached, 1);
+        assert_eq!(accounting.cost_estimate().known_usd, 0.0);
+        assert!(accounting.cost_estimate().complete);
+        assert!(!accounting.is_incomplete());
+    }
+}

--- a/recipe-epub/src/backend.rs
+++ b/recipe-epub/src/backend.rs
@@ -16,9 +16,9 @@ use serde_json::json;
 use crate::library::BookMeta;
 use crate::{
     CallFailure, CallResult, Chunk, ChunkExtractionFailure, ChunkOutcome, CookbookRecipe,
-    EpubError, ExtractProgress, ExtractionStats, ModelTier, OrchestrationOptions, RecipeExtractor,
-    Usage, build_chunk_request, cache, chunk_epub, extract_chunks_with, parse_recipes_payload,
-    try_extract_chunk_detailed,
+    EpubError, ExtractProgress, ExtractionAccounting, ExtractionStats, ModelTier,
+    OrchestrationOptions, RecipeExtractor, Usage, build_chunk_request, cache, chunk_epub,
+    extract_chunks_with, parse_recipes_payload, try_extract_chunk_detailed,
 };
 
 // ===========================================================================
@@ -27,7 +27,7 @@ use crate::{
 // the per-provider HTTP plumbing.
 // ===========================================================================
 
-/// Tunables for [`extract_cookbook`].
+/// Tunables shared by legacy and detailed cookbook extraction.
 #[derive(Debug, Clone)]
 pub struct Options {
     /// Model id override (default: `gemini-2.5-flash`, via the OpenAI-compatible backend).
@@ -64,6 +64,8 @@ impl Default for Options {
 ///
 /// `bytes` is the full `.epub` (a zip). `source` labels each recipe (book path
 /// or title). Auth comes from the environment (see [`ClaudeExtractor::from_env`]).
+/// For per-model costs and truncation evidence, use [`extract_cookbook_detailed`].
+/// Mixed-model legacy stats leave `model` empty and report an unknown cost.
 pub async fn extract_cookbook(
     bytes: &[u8],
     source: &str,
@@ -83,6 +85,27 @@ pub async fn extract_cookbook_with_progress(
     opts: &Options,
     progress: impl Fn(ExtractProgress) + Send + Sync,
 ) -> Result<(Vec<CookbookRecipe>, ExtractionStats), EpubError> {
+    let (recipes, accounting) =
+        extract_cookbook_detailed_with_progress(bytes, source, opts, progress).await?;
+    Ok((recipes, accounting.legacy_stats()))
+}
+
+/// Extract a cookbook with model-attributed accounting and truncation evidence.
+pub async fn extract_cookbook_detailed(
+    bytes: &[u8],
+    source: &str,
+    opts: &Options,
+) -> Result<(Vec<CookbookRecipe>, ExtractionAccounting), EpubError> {
+    extract_cookbook_detailed_with_progress(bytes, source, opts, |_| {}).await
+}
+
+/// Detailed extraction with the existing progress callback contract.
+pub async fn extract_cookbook_detailed_with_progress(
+    bytes: &[u8],
+    source: &str,
+    opts: &Options,
+    progress: impl Fn(ExtractProgress) + Send + Sync,
+) -> Result<(Vec<CookbookRecipe>, ExtractionAccounting), EpubError> {
     let extractor = Backend::from_env(opts, source)?;
     // Build the escalation backend once (a different, usually stronger model),
     // skipped when unset or identical to the primary. Deliberately uncached: it
@@ -245,7 +268,7 @@ async fn extract_cookbook_with_stats<E: RecipeExtractor, F: RecipeExtractor>(
     extractor: &E,
     escalation: Option<&F>,
     progress: &(impl Fn(ExtractProgress) + Send + Sync),
-) -> Result<(Vec<CookbookRecipe>, ExtractionStats), EpubError> {
+) -> Result<(Vec<CookbookRecipe>, ExtractionAccounting), EpubError> {
     let chunks = chunk_epub(bytes)?;
     let total = chunks.len();
     tracing::info!("epub {source}: {total} chunk(s)");
@@ -305,13 +328,7 @@ async fn extract_cookbook_with_stats<E: RecipeExtractor, F: RecipeExtractor>(
         }
     }
 
-    let stats = ExtractionStats {
-        model: extractor.model().to_string(),
-        chunks_total: report.chunks.len() + report.failures.len(),
-        chunks_cached: report.chunks_cached,
-        chunks_failed: report.failures.len(),
-        usage: report.usage,
-    };
+    let stats = report.accounting(extractor.model(), escalation.map(RecipeExtractor::model));
     let recipes = report.recipes;
     tracing::info!(
         "epub {source}: {} recipe(s); {}",
@@ -1089,6 +1106,9 @@ mod tests {
     }
 
     impl RecipeExtractor for FixedExtractor {
+        fn model(&self) -> &str {
+            "claude-sonnet"
+        }
         async fn extract(&self, _chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
             Ok(ChunkOutcome {
                 recipes: Vec::new(),
@@ -1379,6 +1399,9 @@ mod tests {
     }
 
     impl RecipeExtractor for DetailedFailingExtractor {
+        fn model(&self) -> &str {
+            "claude-haiku"
+        }
         async fn extract(&self, _chunk: &Chunk) -> Result<ChunkOutcome, EpubError> {
             Err(EpubError::Proxy("failed".to_string()))
         }
@@ -1494,8 +1517,13 @@ mod tests {
         assert!(stats.summary().contains("1 chunk(s) FAILED"));
     }
 
+    #[rstest::rstest]
+    #[case(false)]
+    #[case(true)]
     #[tokio::test]
-    async fn native_driver_accounts_for_failed_primary_before_fallback_recovery() {
+    async fn native_driver_accounts_for_failed_primary_before_fallback_recovery(
+        #[case] truncated: bool,
+    ) {
         let bytes = minimal_epub();
         let (recipes, stats) = extract_cookbook_with_stats(
             &bytes,
@@ -1503,7 +1531,7 @@ mod tests {
             &Options::default(),
             &DetailedFailingExtractor { input_tokens: 11 },
             Some(&FixedExtractor {
-                truncated: false,
+                truncated,
                 input_tokens: 17,
             }),
             &|_| {},
@@ -1514,7 +1542,14 @@ mod tests {
         assert!(recipes.is_empty());
         assert_eq!(stats.chunks_total, 1);
         assert_eq!(stats.chunks_failed, 0);
+        assert_eq!(stats.chunks_truncated, usize::from(truncated));
+        assert_eq!(stats.is_incomplete(), truncated);
+        assert_eq!(stats.summary().contains("INCOMPLETE"), truncated);
         assert_eq!(stats.usage.input_tokens, 28);
+        assert_eq!(stats.models.len(), 2);
+        assert!((stats.cost_estimate().known_usd - 0.000062).abs() < 1e-12);
+        assert!(stats.cost_estimate().complete);
+        assert!(stats.legacy_stats().cost_usd().is_none());
     }
 
     #[tokio::test]

--- a/recipe-epub/src/lib.rs
+++ b/recipe-epub/src/lib.rs
@@ -32,6 +32,8 @@ mod orchestration;
 // preserve downstream compatibility even when an API has no in-tree caller.
 // CI tests the non-native library and compiles the browser callback example
 // for wasm32.
+mod accounting;
+pub use accounting::{CostEstimate, ExtractionAccounting, ModelUsage};
 pub use epub_text::chunk_epub;
 pub use extractor::{
     CallFailure, CallResult, ChunkExtractionFailure, ChunkOutcome, ChunkRequest, DrivenChunk,
@@ -54,8 +56,8 @@ pub use library::{
 // Keep their existing crate-root paths stable.
 #[cfg(feature = "native")]
 pub use backend::{
-    ChunkDebug, Options, debug_extract_cookbook, extract_cookbook, extract_cookbook_with,
-    extract_cookbook_with_progress,
+    ChunkDebug, Options, debug_extract_cookbook, extract_cookbook, extract_cookbook_detailed,
+    extract_cookbook_detailed_with_progress, extract_cookbook_with, extract_cookbook_with_progress,
 };
 // Section + time types are shared with the web scraper — one shape workspace-wide.
 pub use recipe_scraper::{ParsedSection, RecipeSection, RecipeTimes};
@@ -214,7 +216,8 @@ pub struct ExtractProgress {
 /// Token usage + cost summary for one `extract_cookbook` run.
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct ExtractionStats {
-    /// Resolved model id (empty for the mock).
+    /// Resolved model id. Empty for mocks or mixed-model extraction, whose
+    /// cost cannot be represented here; use the detailed extraction entry points.
     pub model: String,
     /// Total chunks the book was split into.
     pub chunks_total: usize,
@@ -234,14 +237,7 @@ impl ExtractionStats {
     /// Estimated USD cost of the API calls, or `None` if the model's pricing is
     /// unknown. Cache writes bill ~1.25× input, cache reads ~0.1× input.
     pub fn cost_usd(&self) -> Option<f64> {
-        let (in_rate, out_rate) = price_per_mtok(&self.model)?;
-        let u = &self.usage;
-        let cost = (u.input_tokens as f64 * in_rate
-            + u.cache_creation_input_tokens as f64 * in_rate * 1.25
-            + u.cache_read_input_tokens as f64 * in_rate * 0.1
-            + u.output_tokens as f64 * out_rate)
-            / 1_000_000.0;
-        Some(cost)
+        accounting::cost_for_usage(&self.model, &self.usage)
     }
 
     /// One-line human summary for CLI stderr / UI.
@@ -270,33 +266,6 @@ impl ExtractionStats {
             u.cache_read_input_tokens
         )
     }
-}
-
-/// Per-million-token (input, output) USD rates for known models. Matched by
-/// substring so dated ids (`claude-haiku-4-5-20251001`) resolve. `None` → the
-/// cost is reported as "n/a" rather than guessed.
-fn price_per_mtok(model: &str) -> Option<(f64, f64)> {
-    let m = model.to_lowercase();
-    let table = [
-        ("haiku", (1.0, 5.0)),
-        ("sonnet", (3.0, 15.0)),
-        // Pinned to opus-4-5: older Opus models have different (higher) rates,
-        // so they fall through to "n/a" rather than a wrong estimate.
-        ("opus-4-5", (5.0, 25.0)),
-        ("gemini-2.5-flash-lite", (0.10, 0.40)),
-        ("gemini-2.5-flash", (0.30, 2.50)),
-        ("gemini-2.0-flash-lite", (0.075, 0.30)),
-        ("gemini-2.0-flash", (0.10, 0.40)),
-    ];
-    // Longest matching key wins, so the most specific id resolves regardless of
-    // table order: "gemini-2.5-flash-lite" must not match the shorter
-    // "gemini-2.5-flash" prefix. This removes the order-dependence that a plain
-    // first-match `find` would silently rely on.
-    table
-        .iter()
-        .filter(|(key, _)| m.contains(key))
-        .max_by_key(|(key, _)| key.len())
-        .map(|(_, rate)| *rate)
 }
 
 /// Assemble per-chunk extractor output into final recipes and resolve
@@ -799,26 +768,6 @@ mod tests {
             ..Default::default()
         };
         assert!(lossy.summary().contains("2 chunk(s) FAILED"));
-    }
-
-    #[test]
-    fn price_per_mtok_prefers_most_specific_key() {
-        // "...flash-lite" must resolve to the lite rate, not the shorter "flash"
-        // prefix it also contains — longest-match-wins, independent of table order.
-        assert_eq!(
-            price_per_mtok("gemini-2.5-flash-lite-preview"),
-            Some((0.10, 0.40))
-        );
-        assert_eq!(price_per_mtok("gemini-2.5-flash-002"), Some((0.30, 2.50)));
-        assert_eq!(price_per_mtok("gemini-2.0-flash-lite"), Some((0.075, 0.30)));
-        assert_eq!(price_per_mtok("gemini-2.0-flash"), Some((0.10, 0.40)));
-        // Dated Anthropic ids still resolve by substring.
-        assert_eq!(
-            price_per_mtok("claude-haiku-4-5-20251001"),
-            Some((1.0, 5.0))
-        );
-        // Unmapped → None.
-        assert_eq!(price_per_mtok("opus-4-1"), None);
     }
 
     fn er(title: &str, ings: &[&str]) -> ExtractedRecipe {


### PR DESCRIPTION
Rich-text parsing could discard surrounding qualifiers, punctuation, whitespace, or the remainder of a sentence after an unsupported character. The measurement grammar now leaves surrounding prose intact, and the public rich-text parser consumes arbitrary Unicode while retaining normalized Measures.

EPUB extraction previously collapsed primary and fallback usage into a single-model estimate and dropped truncation evidence in native readers. Shared accounting now retains model attribution, reports known cost subtotals as incomplete when rates are missing, and surfaces partial extraction in the CLI and desktop while keeping recovered recipes. Existing public types and entry points remain available; legacy mixed-model estimates are unknown rather than incorrectly priced.

Validation:
- Full workspace: 1,515 tests passed.
- Non-native EPUB: 102 tests passed.
- Ingredient doctests: 26 passed, 2 ignored.
- Strict Clippy across all targets and formatting passed.
- WASM browser EPUB example compiled successfully.
- Regression cases cover Unicode/prose preservation, ranges, fallback billing, unknown model pricing, cache hits, and final versus recovered truncation.
